### PR TITLE
docs: add portfolio standards and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-portfolio-domain-intake.yml
+++ b/.github/ISSUE_TEMPLATE/01-portfolio-domain-intake.yml
@@ -1,0 +1,49 @@
+name: '01. Portfolio Domain Intake / Audit'
+description: Add or audit a domain in the cbmagent portfolio.
+title: '[DOMAIN INTAKE] {domain}'
+labels: ['portfolio', 'domain-inventory', 'readonly', 'status:agent-ready']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for domain inventory, DNS/HTTP audits, redirect classification, and GitHub Pages readiness.
+  - type: input
+    id: domain
+    attributes:
+      label: Domain
+      description: Apex domain, no protocol or path.
+      placeholder: example.com
+    validations:
+      required: true
+  - type: dropdown
+    id: role
+    attributes:
+      label: Domain role
+      options:
+        - canonical-site
+        - redirect-only
+        - staging/subdomain
+        - unknown-audit-needed
+    validations:
+      required: true
+  - type: input
+    id: canonical_target
+    attributes:
+      label: Canonical target if redirect-only
+      placeholder: example.com
+  - type: dropdown
+    id: expected_hosting
+    attributes:
+      label: Expected target hosting
+      options:
+        - github-pages
+        - wordpress-migration-needed
+        - coming-soon-needed
+        - redirect-only-cloudflare
+        - unknown
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes / context

--- a/.github/ISSUE_TEMPLATE/02-agent-work.yml
+++ b/.github/ISSUE_TEMPLATE/02-agent-work.yml
@@ -1,0 +1,36 @@
+name: '02. Agent Work Item'
+description: Track work for Hermes/OpenClaw/Copilot or future agents.
+title: '[AGENT WORK] '
+labels: ['agent-brain', 'status:agent-ready']
+body:
+  - type: textarea
+    id: objective
+    attributes:
+      label: Objective
+      description: What should the agent accomplish?
+    validations:
+      required: true
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      options:
+        - brain-repo-only
+        - cross-repo-coordination
+        - site-repo-work
+        - read-only-audit
+        - write-gated-prep
+    validations:
+      required: true
+  - type: textarea
+    id: constraints
+    attributes:
+      label: Constraints / safety boundaries
+      value: |
+        - Use issue → branch → PR.
+        - Do not commit secrets.
+        - Production writes require protected GitHub Actions environments.
+  - type: textarea
+    id: done
+    attributes:
+      label: Definition of done

--- a/.github/ISSUE_TEMPLATE/03-upstream-giveback.yml
+++ b/.github/ISSUE_TEMPLATE/03-upstream-giveback.yml
@@ -1,0 +1,40 @@
+name: '03. Upstream Giveback Candidate'
+description: Track reusable improvements that should flow back to Free For Charity/source repos.
+title: '[UPSTREAM CANDIDATE] '
+labels: ['upstream-candidate', 'nonprofit-giveback']
+body:
+  - type: dropdown
+    id: source_repo
+    attributes:
+      label: Likely upstream repo
+      options:
+        - FreeForCharity/FFC-IN-FFC_Single_Page_Template
+        - FreeForCharity/FFC-IN-Footer_Only_Template
+        - FreeForCharity/FFC-Cloudflare-Automation
+        - clarkemoyer/technologyadoptionbarriers.org
+        - unknown / needs triage
+    validations:
+      required: true
+  - type: textarea
+    id: improvement
+    attributes:
+      label: Reusable improvement
+      description: What did we learn or build that others can reuse?
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence / downstream usage
+      description: Link downstream issues, PRs, commits, or sites.
+  - type: dropdown
+    id: proposed_action
+    attributes:
+      label: Proposed upstream action
+      options:
+        - open-upstream-issue
+        - open-upstream-pr
+        - document-pattern-only
+        - not-reusable-after-review
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/04-production-write-prep.yml
+++ b/.github/ISSUE_TEMPLATE/04-production-write-prep.yml
@@ -1,0 +1,37 @@
+name: '04. Production Write Preparation'
+description: Prepare a gated production change without bypassing human approval.
+title: '[WRITE-GATED PREP] '
+labels: ['write-gated', 'status:blocked-human']
+body:
+  - type: dropdown
+    id: system
+    attributes:
+      label: External system
+      options:
+        - cloudflare
+        - github
+        - microsoft
+        - google
+        - other
+    validations:
+      required: true
+  - type: textarea
+    id: desired_change
+    attributes:
+      label: Desired production change
+    validations:
+      required: true
+  - type: textarea
+    id: readonly_evidence
+    attributes:
+      label: Read-only preflight evidence
+      description: Paste/link audit output, dry-run report, or workflow artifact.
+  - type: checkboxes
+    id: gates
+    attributes:
+      label: Required gates
+      options:
+        - label: Read-only preflight completed
+        - label: Dry-run plan attached
+        - label: Human approval required before live execution
+        - label: Post-change verification plan defined

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Agent Brain Operating Notes
+    url: https://github.com/cbmagent/cbmagent-brain/blob/main/AGENTS.md
+    about: Review the provider-neutral agent operating rules.

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,63 @@
+- name: documentation
+  description: Documentation and runbook changes
+  color: '0075ca'
+- name: agent-brain
+  description: Provider-neutral agent brain operating model
+  color: '5319e7'
+- name: portfolio
+  description: Cross-repo portfolio/domain tracking
+  color: '1d76db'
+- name: domain-inventory
+  description: Domain, DNS, Cloudflare, or redirect inventory
+  color: '0e8a16'
+- name: github-pages
+  description: GitHub Pages configuration, deployment, or cutover
+  color: '5319e7'
+- name: cloudflare
+  description: Cloudflare DNS, redirects, or zone management
+  color: 'f6821f'
+- name: microsoft
+  description: Microsoft 365, Entra, Graph, DKIM, or Clarity work
+  color: '2f80ed'
+- name: google
+  description: Google Workspace, Analytics, Search Console, or Drive work
+  color: '34a853'
+- name: readonly
+  description: Safe read-only audit/report workflow
+  color: 'c2e0c6'
+- name: write-gated
+  description: Production mutation requiring approval/protected environment
+  color: 'd93f0b'
+- name: upstream-candidate
+  description: Reusable improvement that may belong in a source repo
+  color: 'fbca04'
+- name: nonprofit-giveback
+  description: Work that gives value back to Free For Charity/nonprofit tooling
+  color: 'b60205'
+- name: tabs-alignment
+  description: Alignment with technologyadoptionbarriers.org advanced patterns
+  color: '7057ff'
+- name: provider-usage
+  description: Provider/model/quota/usage monitoring
+  color: 'bfdadc'
+- name: vscode
+  description: VS Code operator workspace or local development console
+  color: '006b75'
+- name: priority:p0
+  description: Critical/urgent
+  color: 'b60205'
+- name: priority:p1
+  description: High priority
+  color: 'd93f0b'
+- name: priority:p2
+  description: Medium priority
+  color: 'fbca04'
+- name: priority:p3
+  description: Low priority
+  color: 'c5def5'
+- name: status:blocked-human
+  description: Waiting on Clarke or another human approval/action
+  color: 'd876e3'
+- name: status:agent-ready
+  description: Ready for autonomous agent work
+  color: '0e8a16'

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+## Summary
+
+-
+
+## Linked Issue
+
+Refs #
+
+## Test / Verification Plan
+
+- [ ] Documentation reviewed
+- [ ] YAML files parse where applicable
+- [ ] No secrets or tokens included
+- [ ] Links/source repo references checked where applicable
+
+## Agent / Provider Notes
+
+- Runtime used:
+- Model/provider if relevant:
+- Reviewer requested:
+
+## Safety / Production Impact
+
+- [ ] No production write is performed by this PR
+- [ ] Any future production write is routed through a protected GitHub Actions environment
+- [ ] Attribution/source lineage updated if derived from source repos
+- [ ] Reusable improvements are tracked as upstream candidates where appropriate

--- a/docs/next-actions.md
+++ b/docs/next-actions.md
@@ -1,0 +1,16 @@
+# Next Actions
+
+## Agent-Ready
+
+1. Run read-only DNS/HTTP audit for all domains in `portfolio/domains.yaml`.
+2. Create or identify GitHub repos for canonical sites.
+3. Build provider usage/limits report script.
+4. Turn attribution policy into reusable README/CITATION templates.
+5. Create source-template alignment issues for Free For Charity giveback.
+
+## Human-Needed Later
+
+- Create scoped read-only Cloudflare API token/environment.
+- Create write-gated Cloudflare production environment with required reviewers.
+- Create scoped Microsoft/Google read-only app credentials if not already available.
+- Approve any live DNS/M365/Google/GitHub production mutations.

--- a/docs/provider-usage-reporting.md
+++ b/docs/provider-usage-reporting.md
@@ -1,0 +1,27 @@
+# Provider Usage and Limits Reporting
+
+Goal: give the agent enough awareness of model/backend availability to route work safely and avoid silent stalls.
+
+## Providers to Track
+
+- OpenAI Codex OAuth / GPT-5.5
+- Nous
+- OpenClaw / GitHub Copilot
+- GitHub Actions minutes/runs
+- Local tools/Ollama if configured
+- Google/Microsoft API quota signals where workflows expose them
+
+## Reality Check
+
+Some subscription/OAuth providers expose limited or opaque quota data. For those providers, track observed rate-limit/cooldown/failure signals from logs and workflow outputs rather than inventing exact limits.
+
+## Report Output
+
+A daily report should include:
+
+- current Hermes provider/model
+- OpenClaw gateway status
+- recent rate-limit/cooldown messages
+- GitHub Actions recent failures/stalls
+- recommended provider routing for the day
+- human tasks needed, if any

--- a/portfolio/domains.yaml
+++ b/portfolio/domains.yaml
@@ -1,0 +1,99 @@
+# cbmagent portfolio domain registry
+# Generated as an initial inventory. Status fields should be updated by read-only DNS/HTTP audits.
+
+default_policy:
+  dot_com_dot_org_pairs: ".com is canonical; .org redirects to .com via Cloudflare unless explicitly overridden"
+  misspellings: "redirect to canonical domain via Cloudflare"
+  production_writes: "prepared by agents, executed only through protected GitHub Actions environments"
+
+domains:
+  - domain: clarkemoyer.com
+    role: canonical-site
+    target_hosting: github-pages
+    repo: cbmagent/clarkemoyer.com
+    current_state: wordpress-migrating-to-nextjs
+    priority: p0
+    notes: "Personal site; existing Next.js migration in progress."
+  - domain: clarkmoyer.com
+    role: redirect-only
+    canonical_target: clarkemoyer.com
+    target_hosting: cloudflare-redirect
+    priority: p2
+    notes: "Misspelling alias."
+  - domain: completequarters.com
+    role: canonical-site
+    target_hosting: github-pages
+    repo: TBD
+    current_state: audit-needed
+    priority: p2
+  - domain: completequarters.org
+    role: redirect-only
+    canonical_target: completequarters.com
+    target_hosting: cloudflare-redirect
+    priority: p3
+  - domain: moyermanagement.com
+    role: canonical-site
+    target_hosting: github-pages
+    repo: TBD
+    current_state: audit-needed
+    priority: p1
+  - domain: moyermanagement.org
+    role: redirect-only
+    canonical_target: moyermanagement.com
+    target_hosting: cloudflare-redirect
+    priority: p3
+  - domain: moyermanagementsystems.com
+    role: canonical-or-related-site
+    target_hosting: github-pages
+    repo: TBD
+    current_state: audit-needed
+    priority: p2
+  - domain: physicalinvestor.com
+    role: canonical-site
+    target_hosting: github-pages
+    repo: TBD
+    current_state: audit-needed
+    priority: p1
+  - domain: technologyadoptionbarriers.org
+    role: canonical-site
+    target_hosting: github-pages
+    repo: clarkemoyer/technologyadoptionbarriers.org
+    current_state: live-production-reference
+    priority: p0
+    notes: "Advanced automation/API/reference repo."
+  - domain: aprilmoyer.com
+    role: canonical-site
+    target_hosting: github-pages
+    repo: TBD
+    current_state: audit-needed
+    priority: p2
+  - domain: aprilunlimited.com
+    role: canonical-site
+    target_hosting: github-pages
+    repo: TBD
+    current_state: audit-needed
+    priority: p2
+  - domain: darkclouds.us
+    role: canonical-site
+    target_hosting: github-pages
+    repo: TBD
+    current_state: audit-needed
+    priority: p3
+  - domain: focus-on-free.com
+    role: canonical-or-related-site
+    target_hosting: github-pages-or-redirect
+    repo: TBD
+    current_state: audit-needed
+    priority: p2
+  - domain: focusonfree.org
+    role: canonical-or-related-site
+    target_hosting: github-pages-or-redirect
+    repo: TBD
+    current_state: audit-needed
+    priority: p2
+  - domain: focusonfree.us
+    role: canonical-or-related-site
+    target_hosting: github-pages-or-redirect
+    repo: TBD
+    current_state: audit-needed
+    priority: p3

--- a/portfolio/upstream-candidates.md
+++ b/portfolio/upstream-candidates.md
@@ -1,0 +1,16 @@
+# Upstream Giveback Candidates
+
+Reusable improvements discovered in portfolio work should be tracked here and in GitHub Issues using the `upstream-candidate` label.
+
+## Candidate Flow
+
+```text
+Downstream site work → identify reusable improvement → open brain issue → open upstream issue/PR → link both directions
+```
+
+## Source Targets
+
+- FreeForCharity/FFC-IN-FFC_Single_Page_Template
+- FreeForCharity/FFC-IN-Footer_Only_Template
+- FreeForCharity/FFC-Cloudflare-Automation
+- clarkemoyer/technologyadoptionbarriers.org

--- a/references/attribution-policy.md
+++ b/references/attribution-policy.md
@@ -1,0 +1,29 @@
+# Attribution Policy
+
+Derived work should credit foundational source repositories and return reusable improvements upstream.
+
+## Default README Acknowledgement
+
+```md
+## Acknowledgements
+
+This site builds on template and automation patterns from Free For Charity:
+
+- [FFC Single Page Template](https://github.com/FreeForCharity/FFC-IN-FFC_Single_Page_Template)
+- [FFC Footer Only Template](https://github.com/FreeForCharity/FFC-IN-Footer_Only_Template)
+- [FFC Cloudflare Automation](https://github.com/FreeForCharity/FFC-Cloudflare-Automation)
+
+Free For Charity provides free technology, website, and operations support for nonprofit organizations.
+```
+
+If TABS patterns are used:
+
+```md
+Additional automation and integration patterns were informed by the public Technology Adoption Barriers project:
+
+- [technologyadoptionbarriers.org](https://github.com/clarkemoyer/technologyadoptionbarriers.org)
+```
+
+## Upstream Rule
+
+If a portfolio implementation creates a reusable improvement, open an upstream issue or PR in the relevant source repo.

--- a/scripts/validate-yaml.py
+++ b/scripts/validate-yaml.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Validate basic YAML files if PyYAML is available; otherwise do a lightweight syntax sanity check."""
+from pathlib import Path
+import sys
+
+paths = [Path('.github/labels.yml'), Path('portfolio/domains.yaml')]
+try:
+    import yaml  # type: ignore
+except Exception:
+    for p in paths:
+        text = p.read_text(encoding='utf-8')
+        if '\t' in text:
+            raise SystemExit(f'{p}: tabs are not allowed in YAML')
+        if not text.strip():
+            raise SystemExit(f'{p}: empty file')
+        print(f'{p}: basic check ok')
+    sys.exit(0)
+
+for p in paths:
+    with p.open(encoding='utf-8') as f:
+        yaml.safe_load(f)
+    print(f'{p}: YAML ok')

--- a/workspaces/cbmagent.code-workspace
+++ b/workspaces/cbmagent.code-workspace
@@ -1,0 +1,28 @@
+{
+  "folders": [
+    {
+      "name": "cbmagent-brain",
+      "path": ".."
+    },
+    {
+      "name": "clarkemoyer.com",
+      "path": "../../clarkemoyer.com"
+    }
+  ],
+  "settings": {
+    "terminal.integrated.defaultProfile.linux": "bash",
+    "git.autofetch": true
+  },
+  "extensions": {
+    "recommendations": [
+      "GitHub.vscode-pull-request-github",
+      "GitHub.vscode-github-actions",
+      "GitHub.copilot",
+      "GitHub.copilot-chat",
+      "DavidAnson.vscode-markdownlint",
+      "redhat.vscode-yaml",
+      "esbenp.prettier-vscode",
+      "ms-playwright.playwright"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary\n\n- Adds GitHub issue forms for domain intake, agent work, upstream giveback, and write-gated production prep\n- Adds PR template and shared label taxonomy\n- Adds structured portfolio domain YAML with canonical/redirect policy\n- Adds attribution and upstream giveback docs\n- Adds provider usage reporting notes and VS Code workspace scaffold\n- Adds lightweight YAML validation script\n\n## Test / Verification Plan\n\n- [x] Ran scripts/validate-yaml.py\n- [x] Verified labels and portfolio YAML parse\n- [x] No secrets or tokens included\n\nRefs #1