### PR TITLE
feat: add first read-only domain audit

### DIFF
--- a/portfolio/dns-audit-reports/2026-05-03T21-34-18Z.json
+++ b/portfolio/dns-audit-reports/2026-05-03T21-34-18Z.json
@@ -1,0 +1,594 @@
+{
+  "domains": [
+    {
+      "a": [],
+      "aaaa": [],
+      "canonical_target": null,
+      "classification": "no-apex-records-detected",
+      "cname": [],
+      "domain": "aprilmoyer.com",
+      "http": {
+        "error": "URLError: <urlopen error [Errno -2] Name or service not known>",
+        "final_url": "http://aprilmoyer.com/",
+        "ok": false,
+        "signals": [],
+        "status": null
+      },
+      "https": {
+        "error": "URLError: <urlopen error [Errno -2] Name or service not known>",
+        "final_url": "https://aprilmoyer.com/",
+        "ok": false,
+        "signals": [],
+        "status": null
+      },
+      "ns": [
+        "cody.ns.cloudflare.com",
+        "lisa.ns.cloudflare.com"
+      ],
+      "repo": "TBD",
+      "role": "canonical-site",
+      "target_hosting": "github-pages",
+      "www_a": [],
+      "www_cname": []
+    },
+    {
+      "a": [
+        "104.21.30.239",
+        "172.67.174.48"
+      ],
+      "aaaa": [
+        "2606:4700:3036::6815:1eef",
+        "2606:4700:3036::ac43:ae30"
+      ],
+      "canonical_target": null,
+      "classification": "wordpress-detected",
+      "cname": [],
+      "domain": "aprilunlimited.com",
+      "http": {
+        "final_url": "https://aprilunlimited.com/",
+        "ok": true,
+        "server": "cloudflare",
+        "signals": [
+          "cloudflare",
+          "wordpress"
+        ],
+        "status": 200
+      },
+      "https": {
+        "final_url": "https://aprilunlimited.com/",
+        "ok": true,
+        "server": "cloudflare",
+        "signals": [
+          "cloudflare",
+          "wordpress"
+        ],
+        "status": 200
+      },
+      "ns": [
+        "cody.ns.cloudflare.com",
+        "lisa.ns.cloudflare.com"
+      ],
+      "repo": "TBD",
+      "role": "canonical-site",
+      "target_hosting": "github-pages",
+      "www_a": [
+        "172.67.174.48",
+        "104.21.30.239"
+      ],
+      "www_cname": []
+    },
+    {
+      "a": [
+        "185.199.111.153",
+        "185.199.108.153",
+        "185.199.110.153",
+        "185.199.109.153"
+      ],
+      "aaaa": [
+        "2606:50c0:8000::153",
+        "2606:50c0:8003::153",
+        "2606:50c0:8002::153",
+        "2606:50c0:8001::153"
+      ],
+      "canonical_target": null,
+      "classification": "github-pages-detected",
+      "cname": [],
+      "domain": "clarkemoyer.com",
+      "http": {
+        "final_url": "https://clarkemoyer.com/",
+        "ok": true,
+        "server": "GitHub.com",
+        "signals": [],
+        "status": 200
+      },
+      "https": {
+        "final_url": "https://clarkemoyer.com/",
+        "ok": true,
+        "server": "GitHub.com",
+        "signals": [],
+        "status": 200
+      },
+      "ns": [
+        "cody.ns.cloudflare.com",
+        "lisa.ns.cloudflare.com"
+      ],
+      "repo": "cbmagent/clarkemoyer.com",
+      "role": "canonical-site",
+      "target_hosting": "github-pages",
+      "www_a": [
+        "clarkemoyer.github.io",
+        "185.199.108.153",
+        "185.199.109.153",
+        "185.199.110.153",
+        "185.199.111.153"
+      ],
+      "www_cname": [
+        "clarkemoyer.github.io"
+      ]
+    },
+    {
+      "a": [
+        "172.67.143.213",
+        "104.21.95.81"
+      ],
+      "aaaa": [
+        "2606:4700:3034::6815:5f51",
+        "2606:4700:3034::ac43:8fd5"
+      ],
+      "canonical_target": "clarkemoyer.com",
+      "classification": "redirect-only-candidate",
+      "cname": [],
+      "domain": "clarkmoyer.com",
+      "http": {
+        "final_url": "https://clarkemoyer.com/",
+        "ok": true,
+        "server": "GitHub.com",
+        "signals": [],
+        "status": 200
+      },
+      "https": {
+        "final_url": "https://clarkemoyer.com/",
+        "ok": true,
+        "server": "GitHub.com",
+        "signals": [],
+        "status": 200
+      },
+      "ns": [
+        "cody.ns.cloudflare.com",
+        "lisa.ns.cloudflare.com"
+      ],
+      "repo": null,
+      "role": "redirect-only",
+      "target_hosting": "cloudflare-redirect",
+      "www_a": [
+        "104.21.95.81",
+        "172.67.143.213"
+      ],
+      "www_cname": []
+    },
+    {
+      "a": [],
+      "aaaa": [],
+      "canonical_target": null,
+      "classification": "no-apex-records-detected",
+      "cname": [],
+      "domain": "completequarters.com",
+      "http": {
+        "error": "URLError: <urlopen error [Errno -2] Name or service not known>",
+        "final_url": "http://completequarters.com/",
+        "ok": false,
+        "signals": [],
+        "status": null
+      },
+      "https": {
+        "error": "URLError: <urlopen error [Errno -2] Name or service not known>",
+        "final_url": "https://completequarters.com/",
+        "ok": false,
+        "signals": [],
+        "status": null
+      },
+      "ns": [
+        "cody.ns.cloudflare.com",
+        "lisa.ns.cloudflare.com"
+      ],
+      "repo": "TBD",
+      "role": "canonical-site",
+      "target_hosting": "github-pages",
+      "www_a": [],
+      "www_cname": []
+    },
+    {
+      "a": [],
+      "aaaa": [],
+      "canonical_target": "completequarters.com",
+      "classification": "redirect-only-candidate",
+      "cname": [],
+      "domain": "completequarters.org",
+      "http": {
+        "error": "URLError: <urlopen error [Errno -2] Name or service not known>",
+        "final_url": "http://completequarters.org/",
+        "ok": false,
+        "signals": [],
+        "status": null
+      },
+      "https": {
+        "error": "URLError: <urlopen error [Errno -2] Name or service not known>",
+        "final_url": "https://completequarters.org/",
+        "ok": false,
+        "signals": [],
+        "status": null
+      },
+      "ns": [
+        "cody.ns.cloudflare.com",
+        "lisa.ns.cloudflare.com"
+      ],
+      "repo": null,
+      "role": "redirect-only",
+      "target_hosting": "cloudflare-redirect",
+      "www_a": [],
+      "www_cname": []
+    },
+    {
+      "a": [],
+      "aaaa": [],
+      "canonical_target": null,
+      "classification": "no-apex-records-detected",
+      "cname": [],
+      "domain": "darkclouds.us",
+      "http": {
+        "error": "URLError: <urlopen error [Errno -2] Name or service not known>",
+        "final_url": "http://darkclouds.us/",
+        "ok": false,
+        "signals": [],
+        "status": null
+      },
+      "https": {
+        "error": "URLError: <urlopen error [Errno -2] Name or service not known>",
+        "final_url": "https://darkclouds.us/",
+        "ok": false,
+        "signals": [],
+        "status": null
+      },
+      "ns": [
+        "cody.ns.cloudflare.com",
+        "lisa.ns.cloudflare.com"
+      ],
+      "repo": "TBD",
+      "role": "canonical-site",
+      "target_hosting": "github-pages",
+      "www_a": [],
+      "www_cname": []
+    },
+    {
+      "a": [
+        "104.21.87.115",
+        "172.67.143.6"
+      ],
+      "aaaa": [
+        "2606:4700:3030::6815:5773",
+        "2606:4700:3032::ac43:8f06"
+      ],
+      "canonical_target": null,
+      "classification": "wordpress-detected",
+      "cname": [],
+      "domain": "focus-on-free.com",
+      "http": {
+        "final_url": "https://focus-on-free.com/",
+        "ok": true,
+        "server": "cloudflare",
+        "signals": [
+          "cloudflare",
+          "wordpress"
+        ],
+        "status": 200
+      },
+      "https": {
+        "final_url": "https://focus-on-free.com/",
+        "ok": true,
+        "server": "cloudflare",
+        "signals": [
+          "cloudflare",
+          "wordpress"
+        ],
+        "status": 200
+      },
+      "ns": [
+        "cody.ns.cloudflare.com",
+        "lisa.ns.cloudflare.com"
+      ],
+      "repo": "TBD",
+      "role": "canonical-or-related-site",
+      "target_hosting": "github-pages-or-redirect",
+      "www_a": [
+        "172.67.143.6",
+        "104.21.87.115"
+      ],
+      "www_cname": []
+    },
+    {
+      "a": [
+        "104.21.21.230",
+        "172.67.200.242"
+      ],
+      "aaaa": [
+        "2606:4700:3032::6815:15e6",
+        "2606:4700:3034::ac43:c8f2"
+      ],
+      "canonical_target": null,
+      "classification": "dns-present-http-issue",
+      "cname": [],
+      "domain": "focusonfree.org",
+      "http": {
+        "error": "HTTP Error 403: Forbidden",
+        "final_url": "http://focusonfree.org/",
+        "ok": false,
+        "signals": [],
+        "status": 403
+      },
+      "https": {
+        "error": "HTTP Error 403: Forbidden",
+        "final_url": "https://focusonfree.org/",
+        "ok": false,
+        "signals": [],
+        "status": 403
+      },
+      "ns": [
+        "cody.ns.cloudflare.com",
+        "lisa.ns.cloudflare.com"
+      ],
+      "repo": "TBD",
+      "role": "canonical-or-related-site",
+      "target_hosting": "github-pages-or-redirect",
+      "www_a": [
+        "104.21.21.230",
+        "172.67.200.242"
+      ],
+      "www_cname": []
+    },
+    {
+      "a": [
+        "172.67.176.160",
+        "104.21.80.88"
+      ],
+      "aaaa": [
+        "2606:4700:3033::ac43:b0a0",
+        "2606:4700:3033::6815:5058"
+      ],
+      "canonical_target": null,
+      "classification": "dns-present-http-issue",
+      "cname": [],
+      "domain": "focusonfree.us",
+      "http": {
+        "error": "HTTP Error 403: Forbidden",
+        "final_url": "http://focusonfree.us/",
+        "ok": false,
+        "signals": [],
+        "status": 403
+      },
+      "https": {
+        "error": "HTTP Error 403: Forbidden",
+        "final_url": "https://focusonfree.us/",
+        "ok": false,
+        "signals": [],
+        "status": 403
+      },
+      "ns": [
+        "cody.ns.cloudflare.com",
+        "lisa.ns.cloudflare.com"
+      ],
+      "repo": "TBD",
+      "role": "canonical-or-related-site",
+      "target_hosting": "github-pages-or-redirect",
+      "www_a": [
+        "172.67.176.160",
+        "104.21.80.88"
+      ],
+      "www_cname": []
+    },
+    {
+      "a": [
+        "172.67.135.216",
+        "104.21.26.99"
+      ],
+      "aaaa": [
+        "2606:4700:3037::ac43:87d8",
+        "2606:4700:3033::6815:1a63"
+      ],
+      "canonical_target": null,
+      "classification": "wordpress-detected",
+      "cname": [],
+      "domain": "moyermanagement.com",
+      "http": {
+        "final_url": "https://moyermanagement.com/",
+        "ok": true,
+        "server": "cloudflare",
+        "signals": [
+          "cloudflare",
+          "wordpress"
+        ],
+        "status": 200
+      },
+      "https": {
+        "final_url": "https://moyermanagement.com/",
+        "ok": true,
+        "server": "cloudflare",
+        "signals": [
+          "cloudflare",
+          "wordpress"
+        ],
+        "status": 200
+      },
+      "ns": [
+        "cody.ns.cloudflare.com",
+        "lisa.ns.cloudflare.com"
+      ],
+      "repo": "TBD",
+      "role": "canonical-site",
+      "target_hosting": "github-pages",
+      "www_a": [
+        "104.21.26.99",
+        "172.67.135.216"
+      ],
+      "www_cname": []
+    },
+    {
+      "a": [
+        "172.67.145.29",
+        "104.21.63.94"
+      ],
+      "aaaa": [
+        "2606:4700:3030::6815:3f5e",
+        "2606:4700:3034::ac43:911d"
+      ],
+      "canonical_target": "moyermanagement.com",
+      "classification": "redirect-only-candidate",
+      "cname": [],
+      "domain": "moyermanagement.org",
+      "http": {
+        "error": "TimeoutError: The read operation timed out",
+        "final_url": "http://moyermanagement.org/",
+        "ok": false,
+        "signals": [],
+        "status": null
+      },
+      "https": {
+        "error": "TimeoutError: The read operation timed out",
+        "final_url": "https://moyermanagement.org/",
+        "ok": false,
+        "signals": [],
+        "status": null
+      },
+      "ns": [
+        "cody.ns.cloudflare.com",
+        "lisa.ns.cloudflare.com"
+      ],
+      "repo": null,
+      "role": "redirect-only",
+      "target_hosting": "cloudflare-redirect",
+      "www_a": [],
+      "www_cname": []
+    },
+    {
+      "a": [],
+      "aaaa": [],
+      "canonical_target": null,
+      "classification": "no-apex-records-detected",
+      "cname": [],
+      "domain": "moyermanagementsystems.com",
+      "http": {
+        "error": "URLError: <urlopen error [Errno -2] Name or service not known>",
+        "final_url": "http://moyermanagementsystems.com/",
+        "ok": false,
+        "signals": [],
+        "status": null
+      },
+      "https": {
+        "error": "URLError: <urlopen error [Errno -2] Name or service not known>",
+        "final_url": "https://moyermanagementsystems.com/",
+        "ok": false,
+        "signals": [],
+        "status": null
+      },
+      "ns": [
+        "cody.ns.cloudflare.com",
+        "lisa.ns.cloudflare.com"
+      ],
+      "repo": "TBD",
+      "role": "canonical-or-related-site",
+      "target_hosting": "github-pages",
+      "www_a": [],
+      "www_cname": []
+    },
+    {
+      "a": [
+        "172.67.172.185",
+        "104.21.30.98"
+      ],
+      "aaaa": [
+        "2606:4700:3033::ac43:acb9",
+        "2606:4700:3032::6815:1e62"
+      ],
+      "canonical_target": null,
+      "classification": "dns-present-http-issue",
+      "cname": [],
+      "domain": "physicalinvestor.com",
+      "http": {
+        "error": "HTTP Error 403: Forbidden",
+        "final_url": "http://physicalinvestor.com/",
+        "ok": false,
+        "signals": [],
+        "status": 403
+      },
+      "https": {
+        "error": "HTTP Error 403: Forbidden",
+        "final_url": "https://physicalinvestor.com/",
+        "ok": false,
+        "signals": [],
+        "status": 403
+      },
+      "ns": [
+        "cody.ns.cloudflare.com",
+        "lisa.ns.cloudflare.com"
+      ],
+      "repo": "TBD",
+      "role": "canonical-site",
+      "target_hosting": "github-pages",
+      "www_a": [
+        "172.67.172.185",
+        "104.21.30.98"
+      ],
+      "www_cname": []
+    },
+    {
+      "a": [
+        "185.199.110.153",
+        "185.199.111.153",
+        "185.199.108.153",
+        "185.199.109.153"
+      ],
+      "aaaa": [
+        "2606:50c0:8001::153",
+        "2606:50c0:8000::153",
+        "2606:50c0:8002::153",
+        "2606:50c0:8003::153"
+      ],
+      "canonical_target": null,
+      "classification": "github-pages-detected",
+      "cname": [],
+      "domain": "technologyadoptionbarriers.org",
+      "http": {
+        "final_url": "https://technologyadoptionbarriers.org/",
+        "ok": true,
+        "server": "GitHub.com",
+        "signals": [],
+        "status": 200
+      },
+      "https": {
+        "final_url": "https://technologyadoptionbarriers.org/",
+        "ok": true,
+        "server": "GitHub.com",
+        "signals": [],
+        "status": 200
+      },
+      "ns": [
+        "ns1.freeforcharity.org",
+        "ns2.freeforcharity.org"
+      ],
+      "repo": "clarkemoyer/technologyadoptionbarriers.org",
+      "role": "canonical-site",
+      "target_hosting": "github-pages",
+      "www_a": [
+        "clarkemoyer.github.io",
+        "185.199.108.153",
+        "185.199.109.153",
+        "185.199.110.153",
+        "185.199.111.153"
+      ],
+      "www_cname": [
+        "clarkemoyer.github.io"
+      ]
+    }
+  ],
+  "generated_at_utc": "2026-05-03T21-34-18Z",
+  "read_only": true
+}

--- a/portfolio/dns-audit-reports/2026-05-03T21-34-18Z.md
+++ b/portfolio/dns-audit-reports/2026-05-03T21-34-18Z.md
@@ -1,0 +1,236 @@
+# Read-Only Domain Audit
+
+Generated UTC: `2026-05-03T21-34-18Z`
+
+This audit used public DNS and HTTP(S) checks only. It did not mutate any provider state.
+
+## Summary
+
+- **aprilmoyer.com**: `no-apex-records-detected`; HTTPS `None` → `https://aprilmoyer.com/`
+- **aprilunlimited.com**: `wordpress-detected`; HTTPS `200` → `https://aprilunlimited.com/`
+- **clarkemoyer.com**: `github-pages-detected`; HTTPS `200` → `https://clarkemoyer.com/`
+- **clarkmoyer.com**: `redirect-only-candidate`; HTTPS `200` → `https://clarkemoyer.com/`
+- **completequarters.com**: `no-apex-records-detected`; HTTPS `None` → `https://completequarters.com/`
+- **completequarters.org**: `redirect-only-candidate`; HTTPS `None` → `https://completequarters.org/`
+- **darkclouds.us**: `no-apex-records-detected`; HTTPS `None` → `https://darkclouds.us/`
+- **focus-on-free.com**: `wordpress-detected`; HTTPS `200` → `https://focus-on-free.com/`
+- **focusonfree.org**: `dns-present-http-issue`; HTTPS `403` → `https://focusonfree.org/`
+- **focusonfree.us**: `dns-present-http-issue`; HTTPS `403` → `https://focusonfree.us/`
+- **moyermanagement.com**: `wordpress-detected`; HTTPS `200` → `https://moyermanagement.com/`
+- **moyermanagement.org**: `redirect-only-candidate`; HTTPS `None` → `https://moyermanagement.org/`
+- **moyermanagementsystems.com**: `no-apex-records-detected`; HTTPS `None` → `https://moyermanagementsystems.com/`
+- **physicalinvestor.com**: `dns-present-http-issue`; HTTPS `403` → `https://physicalinvestor.com/`
+- **technologyadoptionbarriers.org**: `github-pages-detected`; HTTPS `200` → `https://technologyadoptionbarriers.org/`
+
+## Details
+
+### aprilmoyer.com
+
+- Role: `canonical-site`
+- Target hosting: `github-pages`
+- Repo: `TBD`
+- Classification: `no-apex-records-detected`
+- NS: `cody.ns.cloudflare.com, lisa.ns.cloudflare.com`
+- A: `none`
+- AAAA: `none`
+- CNAME apex: `none`
+- www CNAME: `none`
+- HTTPS: `None` `https://aprilmoyer.com/` `URLError: <urlopen error [Errno -2] Name or service not known>`
+- HTTP: `None` `http://aprilmoyer.com/` `URLError: <urlopen error [Errno -2] Name or service not known>`
+
+### aprilunlimited.com
+
+- Role: `canonical-site`
+- Target hosting: `github-pages`
+- Repo: `TBD`
+- Classification: `wordpress-detected`
+- NS: `cody.ns.cloudflare.com, lisa.ns.cloudflare.com`
+- A: `104.21.30.239, 172.67.174.48`
+- AAAA: `2606:4700:3036::6815:1eef, 2606:4700:3036::ac43:ae30`
+- CNAME apex: `none`
+- www CNAME: `none`
+- HTTPS: `200` `https://aprilunlimited.com/` ``
+- HTTP: `200` `https://aprilunlimited.com/` ``
+
+### clarkemoyer.com
+
+- Role: `canonical-site`
+- Target hosting: `github-pages`
+- Repo: `cbmagent/clarkemoyer.com`
+- Classification: `github-pages-detected`
+- NS: `cody.ns.cloudflare.com, lisa.ns.cloudflare.com`
+- A: `185.199.111.153, 185.199.108.153, 185.199.110.153, 185.199.109.153`
+- AAAA: `2606:50c0:8000::153, 2606:50c0:8003::153, 2606:50c0:8002::153, 2606:50c0:8001::153`
+- CNAME apex: `none`
+- www CNAME: `clarkemoyer.github.io`
+- HTTPS: `200` `https://clarkemoyer.com/` ``
+- HTTP: `200` `https://clarkemoyer.com/` ``
+
+### clarkmoyer.com
+
+- Role: `redirect-only`
+- Target hosting: `cloudflare-redirect`
+- Repo: `None`
+- Classification: `redirect-only-candidate`
+- NS: `cody.ns.cloudflare.com, lisa.ns.cloudflare.com`
+- A: `172.67.143.213, 104.21.95.81`
+- AAAA: `2606:4700:3034::6815:5f51, 2606:4700:3034::ac43:8fd5`
+- CNAME apex: `none`
+- www CNAME: `none`
+- HTTPS: `200` `https://clarkemoyer.com/` ``
+- HTTP: `200` `https://clarkemoyer.com/` ``
+
+### completequarters.com
+
+- Role: `canonical-site`
+- Target hosting: `github-pages`
+- Repo: `TBD`
+- Classification: `no-apex-records-detected`
+- NS: `cody.ns.cloudflare.com, lisa.ns.cloudflare.com`
+- A: `none`
+- AAAA: `none`
+- CNAME apex: `none`
+- www CNAME: `none`
+- HTTPS: `None` `https://completequarters.com/` `URLError: <urlopen error [Errno -2] Name or service not known>`
+- HTTP: `None` `http://completequarters.com/` `URLError: <urlopen error [Errno -2] Name or service not known>`
+
+### completequarters.org
+
+- Role: `redirect-only`
+- Target hosting: `cloudflare-redirect`
+- Repo: `None`
+- Classification: `redirect-only-candidate`
+- NS: `cody.ns.cloudflare.com, lisa.ns.cloudflare.com`
+- A: `none`
+- AAAA: `none`
+- CNAME apex: `none`
+- www CNAME: `none`
+- HTTPS: `None` `https://completequarters.org/` `URLError: <urlopen error [Errno -2] Name or service not known>`
+- HTTP: `None` `http://completequarters.org/` `URLError: <urlopen error [Errno -2] Name or service not known>`
+
+### darkclouds.us
+
+- Role: `canonical-site`
+- Target hosting: `github-pages`
+- Repo: `TBD`
+- Classification: `no-apex-records-detected`
+- NS: `cody.ns.cloudflare.com, lisa.ns.cloudflare.com`
+- A: `none`
+- AAAA: `none`
+- CNAME apex: `none`
+- www CNAME: `none`
+- HTTPS: `None` `https://darkclouds.us/` `URLError: <urlopen error [Errno -2] Name or service not known>`
+- HTTP: `None` `http://darkclouds.us/` `URLError: <urlopen error [Errno -2] Name or service not known>`
+
+### focus-on-free.com
+
+- Role: `canonical-or-related-site`
+- Target hosting: `github-pages-or-redirect`
+- Repo: `TBD`
+- Classification: `wordpress-detected`
+- NS: `cody.ns.cloudflare.com, lisa.ns.cloudflare.com`
+- A: `104.21.87.115, 172.67.143.6`
+- AAAA: `2606:4700:3030::6815:5773, 2606:4700:3032::ac43:8f06`
+- CNAME apex: `none`
+- www CNAME: `none`
+- HTTPS: `200` `https://focus-on-free.com/` ``
+- HTTP: `200` `https://focus-on-free.com/` ``
+
+### focusonfree.org
+
+- Role: `canonical-or-related-site`
+- Target hosting: `github-pages-or-redirect`
+- Repo: `TBD`
+- Classification: `dns-present-http-issue`
+- NS: `cody.ns.cloudflare.com, lisa.ns.cloudflare.com`
+- A: `104.21.21.230, 172.67.200.242`
+- AAAA: `2606:4700:3032::6815:15e6, 2606:4700:3034::ac43:c8f2`
+- CNAME apex: `none`
+- www CNAME: `none`
+- HTTPS: `403` `https://focusonfree.org/` `HTTP Error 403: Forbidden`
+- HTTP: `403` `http://focusonfree.org/` `HTTP Error 403: Forbidden`
+
+### focusonfree.us
+
+- Role: `canonical-or-related-site`
+- Target hosting: `github-pages-or-redirect`
+- Repo: `TBD`
+- Classification: `dns-present-http-issue`
+- NS: `cody.ns.cloudflare.com, lisa.ns.cloudflare.com`
+- A: `172.67.176.160, 104.21.80.88`
+- AAAA: `2606:4700:3033::ac43:b0a0, 2606:4700:3033::6815:5058`
+- CNAME apex: `none`
+- www CNAME: `none`
+- HTTPS: `403` `https://focusonfree.us/` `HTTP Error 403: Forbidden`
+- HTTP: `403` `http://focusonfree.us/` `HTTP Error 403: Forbidden`
+
+### moyermanagement.com
+
+- Role: `canonical-site`
+- Target hosting: `github-pages`
+- Repo: `TBD`
+- Classification: `wordpress-detected`
+- NS: `cody.ns.cloudflare.com, lisa.ns.cloudflare.com`
+- A: `172.67.135.216, 104.21.26.99`
+- AAAA: `2606:4700:3037::ac43:87d8, 2606:4700:3033::6815:1a63`
+- CNAME apex: `none`
+- www CNAME: `none`
+- HTTPS: `200` `https://moyermanagement.com/` ``
+- HTTP: `200` `https://moyermanagement.com/` ``
+
+### moyermanagement.org
+
+- Role: `redirect-only`
+- Target hosting: `cloudflare-redirect`
+- Repo: `None`
+- Classification: `redirect-only-candidate`
+- NS: `cody.ns.cloudflare.com, lisa.ns.cloudflare.com`
+- A: `172.67.145.29, 104.21.63.94`
+- AAAA: `2606:4700:3030::6815:3f5e, 2606:4700:3034::ac43:911d`
+- CNAME apex: `none`
+- www CNAME: `none`
+- HTTPS: `None` `https://moyermanagement.org/` `TimeoutError: The read operation timed out`
+- HTTP: `None` `http://moyermanagement.org/` `TimeoutError: The read operation timed out`
+
+### moyermanagementsystems.com
+
+- Role: `canonical-or-related-site`
+- Target hosting: `github-pages`
+- Repo: `TBD`
+- Classification: `no-apex-records-detected`
+- NS: `cody.ns.cloudflare.com, lisa.ns.cloudflare.com`
+- A: `none`
+- AAAA: `none`
+- CNAME apex: `none`
+- www CNAME: `none`
+- HTTPS: `None` `https://moyermanagementsystems.com/` `URLError: <urlopen error [Errno -2] Name or service not known>`
+- HTTP: `None` `http://moyermanagementsystems.com/` `URLError: <urlopen error [Errno -2] Name or service not known>`
+
+### physicalinvestor.com
+
+- Role: `canonical-site`
+- Target hosting: `github-pages`
+- Repo: `TBD`
+- Classification: `dns-present-http-issue`
+- NS: `cody.ns.cloudflare.com, lisa.ns.cloudflare.com`
+- A: `172.67.172.185, 104.21.30.98`
+- AAAA: `2606:4700:3033::ac43:acb9, 2606:4700:3032::6815:1e62`
+- CNAME apex: `none`
+- www CNAME: `none`
+- HTTPS: `403` `https://physicalinvestor.com/` `HTTP Error 403: Forbidden`
+- HTTP: `403` `http://physicalinvestor.com/` `HTTP Error 403: Forbidden`
+
+### technologyadoptionbarriers.org
+
+- Role: `canonical-site`
+- Target hosting: `github-pages`
+- Repo: `clarkemoyer/technologyadoptionbarriers.org`
+- Classification: `github-pages-detected`
+- NS: `ns1.freeforcharity.org, ns2.freeforcharity.org`
+- A: `185.199.110.153, 185.199.111.153, 185.199.108.153, 185.199.109.153`
+- AAAA: `2606:50c0:8001::153, 2606:50c0:8000::153, 2606:50c0:8002::153, 2606:50c0:8003::153`
+- CNAME apex: `none`
+- www CNAME: `clarkemoyer.github.io`
+- HTTPS: `200` `https://technologyadoptionbarriers.org/` ``
+- HTTP: `200` `https://technologyadoptionbarriers.org/` ``
+

--- a/portfolio/dns-audit-reports/latest.json
+++ b/portfolio/dns-audit-reports/latest.json
@@ -1,0 +1,594 @@
+{
+  "domains": [
+    {
+      "a": [],
+      "aaaa": [],
+      "canonical_target": null,
+      "classification": "no-apex-records-detected",
+      "cname": [],
+      "domain": "aprilmoyer.com",
+      "http": {
+        "error": "URLError: <urlopen error [Errno -2] Name or service not known>",
+        "final_url": "http://aprilmoyer.com/",
+        "ok": false,
+        "signals": [],
+        "status": null
+      },
+      "https": {
+        "error": "URLError: <urlopen error [Errno -2] Name or service not known>",
+        "final_url": "https://aprilmoyer.com/",
+        "ok": false,
+        "signals": [],
+        "status": null
+      },
+      "ns": [
+        "cody.ns.cloudflare.com",
+        "lisa.ns.cloudflare.com"
+      ],
+      "repo": "TBD",
+      "role": "canonical-site",
+      "target_hosting": "github-pages",
+      "www_a": [],
+      "www_cname": []
+    },
+    {
+      "a": [
+        "104.21.30.239",
+        "172.67.174.48"
+      ],
+      "aaaa": [
+        "2606:4700:3036::6815:1eef",
+        "2606:4700:3036::ac43:ae30"
+      ],
+      "canonical_target": null,
+      "classification": "wordpress-detected",
+      "cname": [],
+      "domain": "aprilunlimited.com",
+      "http": {
+        "final_url": "https://aprilunlimited.com/",
+        "ok": true,
+        "server": "cloudflare",
+        "signals": [
+          "cloudflare",
+          "wordpress"
+        ],
+        "status": 200
+      },
+      "https": {
+        "final_url": "https://aprilunlimited.com/",
+        "ok": true,
+        "server": "cloudflare",
+        "signals": [
+          "cloudflare",
+          "wordpress"
+        ],
+        "status": 200
+      },
+      "ns": [
+        "cody.ns.cloudflare.com",
+        "lisa.ns.cloudflare.com"
+      ],
+      "repo": "TBD",
+      "role": "canonical-site",
+      "target_hosting": "github-pages",
+      "www_a": [
+        "172.67.174.48",
+        "104.21.30.239"
+      ],
+      "www_cname": []
+    },
+    {
+      "a": [
+        "185.199.111.153",
+        "185.199.108.153",
+        "185.199.110.153",
+        "185.199.109.153"
+      ],
+      "aaaa": [
+        "2606:50c0:8000::153",
+        "2606:50c0:8003::153",
+        "2606:50c0:8002::153",
+        "2606:50c0:8001::153"
+      ],
+      "canonical_target": null,
+      "classification": "github-pages-detected",
+      "cname": [],
+      "domain": "clarkemoyer.com",
+      "http": {
+        "final_url": "https://clarkemoyer.com/",
+        "ok": true,
+        "server": "GitHub.com",
+        "signals": [],
+        "status": 200
+      },
+      "https": {
+        "final_url": "https://clarkemoyer.com/",
+        "ok": true,
+        "server": "GitHub.com",
+        "signals": [],
+        "status": 200
+      },
+      "ns": [
+        "cody.ns.cloudflare.com",
+        "lisa.ns.cloudflare.com"
+      ],
+      "repo": "cbmagent/clarkemoyer.com",
+      "role": "canonical-site",
+      "target_hosting": "github-pages",
+      "www_a": [
+        "clarkemoyer.github.io",
+        "185.199.108.153",
+        "185.199.109.153",
+        "185.199.110.153",
+        "185.199.111.153"
+      ],
+      "www_cname": [
+        "clarkemoyer.github.io"
+      ]
+    },
+    {
+      "a": [
+        "172.67.143.213",
+        "104.21.95.81"
+      ],
+      "aaaa": [
+        "2606:4700:3034::6815:5f51",
+        "2606:4700:3034::ac43:8fd5"
+      ],
+      "canonical_target": "clarkemoyer.com",
+      "classification": "redirect-only-candidate",
+      "cname": [],
+      "domain": "clarkmoyer.com",
+      "http": {
+        "final_url": "https://clarkemoyer.com/",
+        "ok": true,
+        "server": "GitHub.com",
+        "signals": [],
+        "status": 200
+      },
+      "https": {
+        "final_url": "https://clarkemoyer.com/",
+        "ok": true,
+        "server": "GitHub.com",
+        "signals": [],
+        "status": 200
+      },
+      "ns": [
+        "cody.ns.cloudflare.com",
+        "lisa.ns.cloudflare.com"
+      ],
+      "repo": null,
+      "role": "redirect-only",
+      "target_hosting": "cloudflare-redirect",
+      "www_a": [
+        "104.21.95.81",
+        "172.67.143.213"
+      ],
+      "www_cname": []
+    },
+    {
+      "a": [],
+      "aaaa": [],
+      "canonical_target": null,
+      "classification": "no-apex-records-detected",
+      "cname": [],
+      "domain": "completequarters.com",
+      "http": {
+        "error": "URLError: <urlopen error [Errno -2] Name or service not known>",
+        "final_url": "http://completequarters.com/",
+        "ok": false,
+        "signals": [],
+        "status": null
+      },
+      "https": {
+        "error": "URLError: <urlopen error [Errno -2] Name or service not known>",
+        "final_url": "https://completequarters.com/",
+        "ok": false,
+        "signals": [],
+        "status": null
+      },
+      "ns": [
+        "cody.ns.cloudflare.com",
+        "lisa.ns.cloudflare.com"
+      ],
+      "repo": "TBD",
+      "role": "canonical-site",
+      "target_hosting": "github-pages",
+      "www_a": [],
+      "www_cname": []
+    },
+    {
+      "a": [],
+      "aaaa": [],
+      "canonical_target": "completequarters.com",
+      "classification": "redirect-only-candidate",
+      "cname": [],
+      "domain": "completequarters.org",
+      "http": {
+        "error": "URLError: <urlopen error [Errno -2] Name or service not known>",
+        "final_url": "http://completequarters.org/",
+        "ok": false,
+        "signals": [],
+        "status": null
+      },
+      "https": {
+        "error": "URLError: <urlopen error [Errno -2] Name or service not known>",
+        "final_url": "https://completequarters.org/",
+        "ok": false,
+        "signals": [],
+        "status": null
+      },
+      "ns": [
+        "cody.ns.cloudflare.com",
+        "lisa.ns.cloudflare.com"
+      ],
+      "repo": null,
+      "role": "redirect-only",
+      "target_hosting": "cloudflare-redirect",
+      "www_a": [],
+      "www_cname": []
+    },
+    {
+      "a": [],
+      "aaaa": [],
+      "canonical_target": null,
+      "classification": "no-apex-records-detected",
+      "cname": [],
+      "domain": "darkclouds.us",
+      "http": {
+        "error": "URLError: <urlopen error [Errno -2] Name or service not known>",
+        "final_url": "http://darkclouds.us/",
+        "ok": false,
+        "signals": [],
+        "status": null
+      },
+      "https": {
+        "error": "URLError: <urlopen error [Errno -2] Name or service not known>",
+        "final_url": "https://darkclouds.us/",
+        "ok": false,
+        "signals": [],
+        "status": null
+      },
+      "ns": [
+        "cody.ns.cloudflare.com",
+        "lisa.ns.cloudflare.com"
+      ],
+      "repo": "TBD",
+      "role": "canonical-site",
+      "target_hosting": "github-pages",
+      "www_a": [],
+      "www_cname": []
+    },
+    {
+      "a": [
+        "104.21.87.115",
+        "172.67.143.6"
+      ],
+      "aaaa": [
+        "2606:4700:3030::6815:5773",
+        "2606:4700:3032::ac43:8f06"
+      ],
+      "canonical_target": null,
+      "classification": "wordpress-detected",
+      "cname": [],
+      "domain": "focus-on-free.com",
+      "http": {
+        "final_url": "https://focus-on-free.com/",
+        "ok": true,
+        "server": "cloudflare",
+        "signals": [
+          "cloudflare",
+          "wordpress"
+        ],
+        "status": 200
+      },
+      "https": {
+        "final_url": "https://focus-on-free.com/",
+        "ok": true,
+        "server": "cloudflare",
+        "signals": [
+          "cloudflare",
+          "wordpress"
+        ],
+        "status": 200
+      },
+      "ns": [
+        "cody.ns.cloudflare.com",
+        "lisa.ns.cloudflare.com"
+      ],
+      "repo": "TBD",
+      "role": "canonical-or-related-site",
+      "target_hosting": "github-pages-or-redirect",
+      "www_a": [
+        "172.67.143.6",
+        "104.21.87.115"
+      ],
+      "www_cname": []
+    },
+    {
+      "a": [
+        "104.21.21.230",
+        "172.67.200.242"
+      ],
+      "aaaa": [
+        "2606:4700:3032::6815:15e6",
+        "2606:4700:3034::ac43:c8f2"
+      ],
+      "canonical_target": null,
+      "classification": "dns-present-http-issue",
+      "cname": [],
+      "domain": "focusonfree.org",
+      "http": {
+        "error": "HTTP Error 403: Forbidden",
+        "final_url": "http://focusonfree.org/",
+        "ok": false,
+        "signals": [],
+        "status": 403
+      },
+      "https": {
+        "error": "HTTP Error 403: Forbidden",
+        "final_url": "https://focusonfree.org/",
+        "ok": false,
+        "signals": [],
+        "status": 403
+      },
+      "ns": [
+        "cody.ns.cloudflare.com",
+        "lisa.ns.cloudflare.com"
+      ],
+      "repo": "TBD",
+      "role": "canonical-or-related-site",
+      "target_hosting": "github-pages-or-redirect",
+      "www_a": [
+        "104.21.21.230",
+        "172.67.200.242"
+      ],
+      "www_cname": []
+    },
+    {
+      "a": [
+        "172.67.176.160",
+        "104.21.80.88"
+      ],
+      "aaaa": [
+        "2606:4700:3033::ac43:b0a0",
+        "2606:4700:3033::6815:5058"
+      ],
+      "canonical_target": null,
+      "classification": "dns-present-http-issue",
+      "cname": [],
+      "domain": "focusonfree.us",
+      "http": {
+        "error": "HTTP Error 403: Forbidden",
+        "final_url": "http://focusonfree.us/",
+        "ok": false,
+        "signals": [],
+        "status": 403
+      },
+      "https": {
+        "error": "HTTP Error 403: Forbidden",
+        "final_url": "https://focusonfree.us/",
+        "ok": false,
+        "signals": [],
+        "status": 403
+      },
+      "ns": [
+        "cody.ns.cloudflare.com",
+        "lisa.ns.cloudflare.com"
+      ],
+      "repo": "TBD",
+      "role": "canonical-or-related-site",
+      "target_hosting": "github-pages-or-redirect",
+      "www_a": [
+        "172.67.176.160",
+        "104.21.80.88"
+      ],
+      "www_cname": []
+    },
+    {
+      "a": [
+        "172.67.135.216",
+        "104.21.26.99"
+      ],
+      "aaaa": [
+        "2606:4700:3037::ac43:87d8",
+        "2606:4700:3033::6815:1a63"
+      ],
+      "canonical_target": null,
+      "classification": "wordpress-detected",
+      "cname": [],
+      "domain": "moyermanagement.com",
+      "http": {
+        "final_url": "https://moyermanagement.com/",
+        "ok": true,
+        "server": "cloudflare",
+        "signals": [
+          "cloudflare",
+          "wordpress"
+        ],
+        "status": 200
+      },
+      "https": {
+        "final_url": "https://moyermanagement.com/",
+        "ok": true,
+        "server": "cloudflare",
+        "signals": [
+          "cloudflare",
+          "wordpress"
+        ],
+        "status": 200
+      },
+      "ns": [
+        "cody.ns.cloudflare.com",
+        "lisa.ns.cloudflare.com"
+      ],
+      "repo": "TBD",
+      "role": "canonical-site",
+      "target_hosting": "github-pages",
+      "www_a": [
+        "104.21.26.99",
+        "172.67.135.216"
+      ],
+      "www_cname": []
+    },
+    {
+      "a": [
+        "172.67.145.29",
+        "104.21.63.94"
+      ],
+      "aaaa": [
+        "2606:4700:3030::6815:3f5e",
+        "2606:4700:3034::ac43:911d"
+      ],
+      "canonical_target": "moyermanagement.com",
+      "classification": "redirect-only-candidate",
+      "cname": [],
+      "domain": "moyermanagement.org",
+      "http": {
+        "error": "TimeoutError: The read operation timed out",
+        "final_url": "http://moyermanagement.org/",
+        "ok": false,
+        "signals": [],
+        "status": null
+      },
+      "https": {
+        "error": "TimeoutError: The read operation timed out",
+        "final_url": "https://moyermanagement.org/",
+        "ok": false,
+        "signals": [],
+        "status": null
+      },
+      "ns": [
+        "cody.ns.cloudflare.com",
+        "lisa.ns.cloudflare.com"
+      ],
+      "repo": null,
+      "role": "redirect-only",
+      "target_hosting": "cloudflare-redirect",
+      "www_a": [],
+      "www_cname": []
+    },
+    {
+      "a": [],
+      "aaaa": [],
+      "canonical_target": null,
+      "classification": "no-apex-records-detected",
+      "cname": [],
+      "domain": "moyermanagementsystems.com",
+      "http": {
+        "error": "URLError: <urlopen error [Errno -2] Name or service not known>",
+        "final_url": "http://moyermanagementsystems.com/",
+        "ok": false,
+        "signals": [],
+        "status": null
+      },
+      "https": {
+        "error": "URLError: <urlopen error [Errno -2] Name or service not known>",
+        "final_url": "https://moyermanagementsystems.com/",
+        "ok": false,
+        "signals": [],
+        "status": null
+      },
+      "ns": [
+        "cody.ns.cloudflare.com",
+        "lisa.ns.cloudflare.com"
+      ],
+      "repo": "TBD",
+      "role": "canonical-or-related-site",
+      "target_hosting": "github-pages",
+      "www_a": [],
+      "www_cname": []
+    },
+    {
+      "a": [
+        "172.67.172.185",
+        "104.21.30.98"
+      ],
+      "aaaa": [
+        "2606:4700:3033::ac43:acb9",
+        "2606:4700:3032::6815:1e62"
+      ],
+      "canonical_target": null,
+      "classification": "dns-present-http-issue",
+      "cname": [],
+      "domain": "physicalinvestor.com",
+      "http": {
+        "error": "HTTP Error 403: Forbidden",
+        "final_url": "http://physicalinvestor.com/",
+        "ok": false,
+        "signals": [],
+        "status": 403
+      },
+      "https": {
+        "error": "HTTP Error 403: Forbidden",
+        "final_url": "https://physicalinvestor.com/",
+        "ok": false,
+        "signals": [],
+        "status": 403
+      },
+      "ns": [
+        "cody.ns.cloudflare.com",
+        "lisa.ns.cloudflare.com"
+      ],
+      "repo": "TBD",
+      "role": "canonical-site",
+      "target_hosting": "github-pages",
+      "www_a": [
+        "172.67.172.185",
+        "104.21.30.98"
+      ],
+      "www_cname": []
+    },
+    {
+      "a": [
+        "185.199.110.153",
+        "185.199.111.153",
+        "185.199.108.153",
+        "185.199.109.153"
+      ],
+      "aaaa": [
+        "2606:50c0:8001::153",
+        "2606:50c0:8000::153",
+        "2606:50c0:8002::153",
+        "2606:50c0:8003::153"
+      ],
+      "canonical_target": null,
+      "classification": "github-pages-detected",
+      "cname": [],
+      "domain": "technologyadoptionbarriers.org",
+      "http": {
+        "final_url": "https://technologyadoptionbarriers.org/",
+        "ok": true,
+        "server": "GitHub.com",
+        "signals": [],
+        "status": 200
+      },
+      "https": {
+        "final_url": "https://technologyadoptionbarriers.org/",
+        "ok": true,
+        "server": "GitHub.com",
+        "signals": [],
+        "status": 200
+      },
+      "ns": [
+        "ns1.freeforcharity.org",
+        "ns2.freeforcharity.org"
+      ],
+      "repo": "clarkemoyer/technologyadoptionbarriers.org",
+      "role": "canonical-site",
+      "target_hosting": "github-pages",
+      "www_a": [
+        "clarkemoyer.github.io",
+        "185.199.108.153",
+        "185.199.109.153",
+        "185.199.110.153",
+        "185.199.111.153"
+      ],
+      "www_cname": [
+        "clarkemoyer.github.io"
+      ]
+    }
+  ],
+  "generated_at_utc": "2026-05-03T21-34-18Z",
+  "read_only": true
+}

--- a/portfolio/dns-audit-reports/latest.md
+++ b/portfolio/dns-audit-reports/latest.md
@@ -1,0 +1,236 @@
+# Read-Only Domain Audit
+
+Generated UTC: `2026-05-03T21-34-18Z`
+
+This audit used public DNS and HTTP(S) checks only. It did not mutate any provider state.
+
+## Summary
+
+- **aprilmoyer.com**: `no-apex-records-detected`; HTTPS `None` → `https://aprilmoyer.com/`
+- **aprilunlimited.com**: `wordpress-detected`; HTTPS `200` → `https://aprilunlimited.com/`
+- **clarkemoyer.com**: `github-pages-detected`; HTTPS `200` → `https://clarkemoyer.com/`
+- **clarkmoyer.com**: `redirect-only-candidate`; HTTPS `200` → `https://clarkemoyer.com/`
+- **completequarters.com**: `no-apex-records-detected`; HTTPS `None` → `https://completequarters.com/`
+- **completequarters.org**: `redirect-only-candidate`; HTTPS `None` → `https://completequarters.org/`
+- **darkclouds.us**: `no-apex-records-detected`; HTTPS `None` → `https://darkclouds.us/`
+- **focus-on-free.com**: `wordpress-detected`; HTTPS `200` → `https://focus-on-free.com/`
+- **focusonfree.org**: `dns-present-http-issue`; HTTPS `403` → `https://focusonfree.org/`
+- **focusonfree.us**: `dns-present-http-issue`; HTTPS `403` → `https://focusonfree.us/`
+- **moyermanagement.com**: `wordpress-detected`; HTTPS `200` → `https://moyermanagement.com/`
+- **moyermanagement.org**: `redirect-only-candidate`; HTTPS `None` → `https://moyermanagement.org/`
+- **moyermanagementsystems.com**: `no-apex-records-detected`; HTTPS `None` → `https://moyermanagementsystems.com/`
+- **physicalinvestor.com**: `dns-present-http-issue`; HTTPS `403` → `https://physicalinvestor.com/`
+- **technologyadoptionbarriers.org**: `github-pages-detected`; HTTPS `200` → `https://technologyadoptionbarriers.org/`
+
+## Details
+
+### aprilmoyer.com
+
+- Role: `canonical-site`
+- Target hosting: `github-pages`
+- Repo: `TBD`
+- Classification: `no-apex-records-detected`
+- NS: `cody.ns.cloudflare.com, lisa.ns.cloudflare.com`
+- A: `none`
+- AAAA: `none`
+- CNAME apex: `none`
+- www CNAME: `none`
+- HTTPS: `None` `https://aprilmoyer.com/` `URLError: <urlopen error [Errno -2] Name or service not known>`
+- HTTP: `None` `http://aprilmoyer.com/` `URLError: <urlopen error [Errno -2] Name or service not known>`
+
+### aprilunlimited.com
+
+- Role: `canonical-site`
+- Target hosting: `github-pages`
+- Repo: `TBD`
+- Classification: `wordpress-detected`
+- NS: `cody.ns.cloudflare.com, lisa.ns.cloudflare.com`
+- A: `104.21.30.239, 172.67.174.48`
+- AAAA: `2606:4700:3036::6815:1eef, 2606:4700:3036::ac43:ae30`
+- CNAME apex: `none`
+- www CNAME: `none`
+- HTTPS: `200` `https://aprilunlimited.com/` ``
+- HTTP: `200` `https://aprilunlimited.com/` ``
+
+### clarkemoyer.com
+
+- Role: `canonical-site`
+- Target hosting: `github-pages`
+- Repo: `cbmagent/clarkemoyer.com`
+- Classification: `github-pages-detected`
+- NS: `cody.ns.cloudflare.com, lisa.ns.cloudflare.com`
+- A: `185.199.111.153, 185.199.108.153, 185.199.110.153, 185.199.109.153`
+- AAAA: `2606:50c0:8000::153, 2606:50c0:8003::153, 2606:50c0:8002::153, 2606:50c0:8001::153`
+- CNAME apex: `none`
+- www CNAME: `clarkemoyer.github.io`
+- HTTPS: `200` `https://clarkemoyer.com/` ``
+- HTTP: `200` `https://clarkemoyer.com/` ``
+
+### clarkmoyer.com
+
+- Role: `redirect-only`
+- Target hosting: `cloudflare-redirect`
+- Repo: `None`
+- Classification: `redirect-only-candidate`
+- NS: `cody.ns.cloudflare.com, lisa.ns.cloudflare.com`
+- A: `172.67.143.213, 104.21.95.81`
+- AAAA: `2606:4700:3034::6815:5f51, 2606:4700:3034::ac43:8fd5`
+- CNAME apex: `none`
+- www CNAME: `none`
+- HTTPS: `200` `https://clarkemoyer.com/` ``
+- HTTP: `200` `https://clarkemoyer.com/` ``
+
+### completequarters.com
+
+- Role: `canonical-site`
+- Target hosting: `github-pages`
+- Repo: `TBD`
+- Classification: `no-apex-records-detected`
+- NS: `cody.ns.cloudflare.com, lisa.ns.cloudflare.com`
+- A: `none`
+- AAAA: `none`
+- CNAME apex: `none`
+- www CNAME: `none`
+- HTTPS: `None` `https://completequarters.com/` `URLError: <urlopen error [Errno -2] Name or service not known>`
+- HTTP: `None` `http://completequarters.com/` `URLError: <urlopen error [Errno -2] Name or service not known>`
+
+### completequarters.org
+
+- Role: `redirect-only`
+- Target hosting: `cloudflare-redirect`
+- Repo: `None`
+- Classification: `redirect-only-candidate`
+- NS: `cody.ns.cloudflare.com, lisa.ns.cloudflare.com`
+- A: `none`
+- AAAA: `none`
+- CNAME apex: `none`
+- www CNAME: `none`
+- HTTPS: `None` `https://completequarters.org/` `URLError: <urlopen error [Errno -2] Name or service not known>`
+- HTTP: `None` `http://completequarters.org/` `URLError: <urlopen error [Errno -2] Name or service not known>`
+
+### darkclouds.us
+
+- Role: `canonical-site`
+- Target hosting: `github-pages`
+- Repo: `TBD`
+- Classification: `no-apex-records-detected`
+- NS: `cody.ns.cloudflare.com, lisa.ns.cloudflare.com`
+- A: `none`
+- AAAA: `none`
+- CNAME apex: `none`
+- www CNAME: `none`
+- HTTPS: `None` `https://darkclouds.us/` `URLError: <urlopen error [Errno -2] Name or service not known>`
+- HTTP: `None` `http://darkclouds.us/` `URLError: <urlopen error [Errno -2] Name or service not known>`
+
+### focus-on-free.com
+
+- Role: `canonical-or-related-site`
+- Target hosting: `github-pages-or-redirect`
+- Repo: `TBD`
+- Classification: `wordpress-detected`
+- NS: `cody.ns.cloudflare.com, lisa.ns.cloudflare.com`
+- A: `104.21.87.115, 172.67.143.6`
+- AAAA: `2606:4700:3030::6815:5773, 2606:4700:3032::ac43:8f06`
+- CNAME apex: `none`
+- www CNAME: `none`
+- HTTPS: `200` `https://focus-on-free.com/` ``
+- HTTP: `200` `https://focus-on-free.com/` ``
+
+### focusonfree.org
+
+- Role: `canonical-or-related-site`
+- Target hosting: `github-pages-or-redirect`
+- Repo: `TBD`
+- Classification: `dns-present-http-issue`
+- NS: `cody.ns.cloudflare.com, lisa.ns.cloudflare.com`
+- A: `104.21.21.230, 172.67.200.242`
+- AAAA: `2606:4700:3032::6815:15e6, 2606:4700:3034::ac43:c8f2`
+- CNAME apex: `none`
+- www CNAME: `none`
+- HTTPS: `403` `https://focusonfree.org/` `HTTP Error 403: Forbidden`
+- HTTP: `403` `http://focusonfree.org/` `HTTP Error 403: Forbidden`
+
+### focusonfree.us
+
+- Role: `canonical-or-related-site`
+- Target hosting: `github-pages-or-redirect`
+- Repo: `TBD`
+- Classification: `dns-present-http-issue`
+- NS: `cody.ns.cloudflare.com, lisa.ns.cloudflare.com`
+- A: `172.67.176.160, 104.21.80.88`
+- AAAA: `2606:4700:3033::ac43:b0a0, 2606:4700:3033::6815:5058`
+- CNAME apex: `none`
+- www CNAME: `none`
+- HTTPS: `403` `https://focusonfree.us/` `HTTP Error 403: Forbidden`
+- HTTP: `403` `http://focusonfree.us/` `HTTP Error 403: Forbidden`
+
+### moyermanagement.com
+
+- Role: `canonical-site`
+- Target hosting: `github-pages`
+- Repo: `TBD`
+- Classification: `wordpress-detected`
+- NS: `cody.ns.cloudflare.com, lisa.ns.cloudflare.com`
+- A: `172.67.135.216, 104.21.26.99`
+- AAAA: `2606:4700:3037::ac43:87d8, 2606:4700:3033::6815:1a63`
+- CNAME apex: `none`
+- www CNAME: `none`
+- HTTPS: `200` `https://moyermanagement.com/` ``
+- HTTP: `200` `https://moyermanagement.com/` ``
+
+### moyermanagement.org
+
+- Role: `redirect-only`
+- Target hosting: `cloudflare-redirect`
+- Repo: `None`
+- Classification: `redirect-only-candidate`
+- NS: `cody.ns.cloudflare.com, lisa.ns.cloudflare.com`
+- A: `172.67.145.29, 104.21.63.94`
+- AAAA: `2606:4700:3030::6815:3f5e, 2606:4700:3034::ac43:911d`
+- CNAME apex: `none`
+- www CNAME: `none`
+- HTTPS: `None` `https://moyermanagement.org/` `TimeoutError: The read operation timed out`
+- HTTP: `None` `http://moyermanagement.org/` `TimeoutError: The read operation timed out`
+
+### moyermanagementsystems.com
+
+- Role: `canonical-or-related-site`
+- Target hosting: `github-pages`
+- Repo: `TBD`
+- Classification: `no-apex-records-detected`
+- NS: `cody.ns.cloudflare.com, lisa.ns.cloudflare.com`
+- A: `none`
+- AAAA: `none`
+- CNAME apex: `none`
+- www CNAME: `none`
+- HTTPS: `None` `https://moyermanagementsystems.com/` `URLError: <urlopen error [Errno -2] Name or service not known>`
+- HTTP: `None` `http://moyermanagementsystems.com/` `URLError: <urlopen error [Errno -2] Name or service not known>`
+
+### physicalinvestor.com
+
+- Role: `canonical-site`
+- Target hosting: `github-pages`
+- Repo: `TBD`
+- Classification: `dns-present-http-issue`
+- NS: `cody.ns.cloudflare.com, lisa.ns.cloudflare.com`
+- A: `172.67.172.185, 104.21.30.98`
+- AAAA: `2606:4700:3033::ac43:acb9, 2606:4700:3032::6815:1e62`
+- CNAME apex: `none`
+- www CNAME: `none`
+- HTTPS: `403` `https://physicalinvestor.com/` `HTTP Error 403: Forbidden`
+- HTTP: `403` `http://physicalinvestor.com/` `HTTP Error 403: Forbidden`
+
+### technologyadoptionbarriers.org
+
+- Role: `canonical-site`
+- Target hosting: `github-pages`
+- Repo: `clarkemoyer/technologyadoptionbarriers.org`
+- Classification: `github-pages-detected`
+- NS: `ns1.freeforcharity.org, ns2.freeforcharity.org`
+- A: `185.199.110.153, 185.199.111.153, 185.199.108.153, 185.199.109.153`
+- AAAA: `2606:50c0:8001::153, 2606:50c0:8000::153, 2606:50c0:8002::153, 2606:50c0:8003::153`
+- CNAME apex: `none`
+- www CNAME: `clarkemoyer.github.io`
+- HTTPS: `200` `https://technologyadoptionbarriers.org/` ``
+- HTTP: `200` `https://technologyadoptionbarriers.org/` ``
+

--- a/scripts/domain-readonly-audit.py
+++ b/scripts/domain-readonly-audit.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Read-only DNS/HTTP audit for portfolio domains.
+
+No credentials required. Does not mutate DNS, Cloudflare, GitHub, Microsoft, or Google.
+"""
+from __future__ import annotations
+import concurrent.futures as cf
+import datetime as dt
+import json
+import re
+import socket
+import ssl
+import subprocess
+import sys
+from pathlib import Path
+from urllib.request import Request, urlopen
+from urllib.error import URLError, HTTPError
+
+DOMAINS_YAML = Path('portfolio/domains.yaml')
+OUT_DIR = Path('portfolio/dns-audit-reports')
+
+
+def load_domains() -> list[dict]:
+    try:
+        import yaml  # type: ignore
+    except Exception:
+        text = DOMAINS_YAML.read_text(encoding='utf-8')
+        return [{'domain': m.group(1)} for m in re.finditer(r'^\s*- domain:\s*([^\s]+)', text, re.M)]
+    data = yaml.safe_load(DOMAINS_YAML.read_text(encoding='utf-8')) or {}
+    return data.get('domains', [])
+
+
+def dig(domain: str, rtype: str) -> list[str]:
+    try:
+        p = subprocess.run(['dig', '+short', rtype, domain], text=True, capture_output=True, timeout=10)
+        if p.returncode != 0:
+            return []
+        return [x.strip().rstrip('.') for x in p.stdout.splitlines() if x.strip()]
+    except Exception:
+        return []
+
+
+def http_check(domain: str, scheme: str) -> dict:
+    url = f'{scheme}://{domain}/'
+    req = Request(url, headers={'User-Agent': 'cbmagent-brain-readonly-audit/0.1'})
+    try:
+        ctx = ssl.create_default_context()
+        with urlopen(req, timeout=12, context=ctx) as resp:
+            body = resp.read(200000).decode('utf-8', 'ignore')
+            final_url = resp.geturl()
+            headers = {k.lower(): v for k, v in resp.headers.items()}
+            signals = []
+            hay = (body[:50000] + '\n' + '\n'.join(f'{k}: {v}' for k, v in headers.items())).lower()
+            if 'wp-content' in hay or 'wp-includes' in hay or 'wordpress' in hay:
+                signals.append('wordpress')
+            if 'github.io' in hay or 'github pages' in hay:
+                signals.append('github-pages')
+            if 'cloudflare' in headers.get('server', '').lower() or headers.get('cf-ray'):
+                signals.append('cloudflare')
+            return {'ok': True, 'status': resp.status, 'final_url': final_url, 'server': headers.get('server', ''), 'signals': sorted(set(signals))}
+    except HTTPError as e:
+        return {'ok': False, 'status': e.code, 'error': str(e), 'final_url': url, 'signals': []}
+    except Exception as e:
+        return {'ok': False, 'status': None, 'error': type(e).__name__ + ': ' + str(e), 'final_url': url, 'signals': []}
+
+
+def classify(domain: str, rec: dict, meta: dict) -> str:
+    if meta.get('role') == 'redirect-only':
+        return 'redirect-only-candidate'
+    signals = set(rec.get('https', {}).get('signals') or []) | set(rec.get('http', {}).get('signals') or [])
+    c = ' '.join(rec.get('cname', []) + rec.get('www_cname', [])).lower()
+    ips = set(rec.get('a', []))
+    gh_ips = {'185.199.108.153', '185.199.109.153', '185.199.110.153', '185.199.111.153'}
+    if 'wordpress' in signals:
+        return 'wordpress-detected'
+    if 'github-pages' in signals or 'github.io' in c or ips.intersection(gh_ips):
+        return 'github-pages-detected'
+    if rec.get('https', {}).get('ok') or rec.get('http', {}).get('ok'):
+        return 'live-other-or-unknown'
+    if not rec.get('a') and not rec.get('aaaa') and not rec.get('cname'):
+        return 'no-apex-records-detected'
+    return 'dns-present-http-issue'
+
+
+def audit_one(meta: dict) -> dict:
+    d = meta['domain']
+    rec = {
+        'domain': d,
+        'role': meta.get('role'),
+        'canonical_target': meta.get('canonical_target'),
+        'target_hosting': meta.get('target_hosting'),
+        'repo': meta.get('repo'),
+        'ns': dig(d, 'NS'),
+        'a': dig(d, 'A'),
+        'aaaa': dig(d, 'AAAA'),
+        'cname': dig(d, 'CNAME'),
+        'www_cname': dig('www.' + d, 'CNAME'),
+        'www_a': dig('www.' + d, 'A'),
+        'https': http_check(d, 'https'),
+        'http': http_check(d, 'http'),
+    }
+    rec['classification'] = classify(d, rec, meta)
+    return rec
+
+
+def main() -> int:
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    domains = load_domains()
+    ts = dt.datetime.now(dt.timezone.utc).strftime('%Y-%m-%dT%H-%M-%SZ')
+    with cf.ThreadPoolExecutor(max_workers=8) as ex:
+        rows = list(ex.map(audit_one, domains))
+    rows.sort(key=lambda r: r['domain'])
+    json_path = OUT_DIR / f'{ts}.json'
+    md_path = OUT_DIR / f'{ts}.md'
+    latest_json = OUT_DIR / 'latest.json'
+    latest_md = OUT_DIR / 'latest.md'
+    payload = {'generated_at_utc': ts, 'read_only': True, 'domains': rows}
+    json_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + '\n', encoding='utf-8')
+    latest_json.write_text(json.dumps(payload, indent=2, sort_keys=True) + '\n', encoding='utf-8')
+    lines = [f'# Read-Only Domain Audit', '', f'Generated UTC: `{ts}`', '', 'This audit used public DNS and HTTP(S) checks only. It did not mutate any provider state.', '', '## Summary', '']
+    for r in rows:
+        lines.append(f"- **{r['domain']}**: `{r['classification']}`; HTTPS `{r['https'].get('status')}` → `{r['https'].get('final_url')}`")
+    lines += ['', '## Details', '']
+    for r in rows:
+        lines += [f"### {r['domain']}", '', f"- Role: `{r.get('role')}`", f"- Target hosting: `{r.get('target_hosting')}`", f"- Repo: `{r.get('repo')}`", f"- Classification: `{r['classification']}`", f"- NS: `{', '.join(r['ns']) or 'none'}`", f"- A: `{', '.join(r['a']) or 'none'}`", f"- AAAA: `{', '.join(r['aaaa']) or 'none'}`", f"- CNAME apex: `{', '.join(r['cname']) or 'none'}`", f"- www CNAME: `{', '.join(r['www_cname']) or 'none'}`", f"- HTTPS: `{r['https'].get('status')}` `{r['https'].get('final_url')}` `{r['https'].get('error','')}`", f"- HTTP: `{r['http'].get('status')}` `{r['http'].get('final_url')}` `{r['http'].get('error','')}`", '']
+    md_path.write_text('\n'.join(lines) + '\n', encoding='utf-8')
+    latest_md.write_text('\n'.join(lines) + '\n', encoding='utf-8')
+    print(md_path)
+    return 0
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary\n\n- Adds a read-only DNS/HTTP audit script for portfolio domains\n- Runs the first audit against portfolio/domains.yaml\n- Stores timestamped and latest Markdown/JSON audit reports\n\n## Initial Findings\n\n- clarkemoyer.com and technologyadoptionbarriers.org look GitHub Pages-backed\n- aprilunlimited.com, focus-on-free.com, and moyermanagement.com show WordPress signals\n- clarkmoyer.com redirects to clarkemoyer.com as expected\n- several canonical/redirect domains have no apex records yet and are good coming-soon/GitHub Pages candidates\n- focusonfree.org, focusonfree.us, and physicalinvestor.com returned HTTP 403 through public checks\n\n## Test / Verification Plan\n\n- [x] Ran scripts/domain-readonly-audit.py\n- [x] Ran scripts/validate-yaml.py\n- [x] Confirmed no provider credentials/secrets were used\n\nCloses #3