### PR TITLE
feat: add provider usage report v0

### DIFF
--- a/reports/provider-usage/2026-05-03T21-36-23Z.json
+++ b/reports/provider-usage/2026-05-03T21-36-23Z.json
@@ -1,0 +1,86 @@
+{
+  "commands": {
+    "gh_auth_status": {
+      "exit_code": 0,
+      "ok": true,
+      "stderr": "",
+      "stdout": "github.com\n  \u2713 Logged in to github.com account cbmagent (keyring)\n  - Active account: true\n  - Git operations protocol: https\n  - Token: [REDACTED]\n  - Token scopes: 'admin:enterprise', 'admin:gpg_key', 'admin:org', 'admin:org_hook', 'admin:public_key', 'admin:repo_hook', 'admin:ssh_signing_key', 'audit_log', 'codespace', 'copilot', 'delete:packages', 'delete_repo', 'gist', 'notifications', 'project', 'repo', 'user', 'workflow', 'write:discussion', 'write:network_configurations', 'write:packages'\n\n  \u2713 Logged in to github.com account clarkemoyer (/home/cbmagent/.config/gh/hosts.yml)\n  - Active account: false\n  - Git operations protocol: https\n  - Token: [REDACTED]\n  - Token scopes: 'gist', 'read:org', 'repo', 'workflow'\n"
+    },
+    "hermes_auth_list_names_only": {
+      "exit_code": 0,
+      "ok": true,
+      "stderr": "",
+      "stdout": "copilot (1 credentials):\n  #1  gh auth [REDACTED]\n\nnous (1 credentials):\n  #1  device_code          oauth   device_code \u2190\n\nopenai-codex (1 credentials):\n  #1  openai-codex-oauth-1 oauth   device_code \u2190\n\n"
+    },
+    "hermes_config_provider_model": {
+      "exit_code": 0,
+      "ok": true,
+      "stderr": "",
+      "stdout": "\u25c6 Model\n  Model:        {'default': 'gpt-5.5', 'provider': 'openai-codex'}\n  Model:        (auto)\n"
+    },
+    "hermes_status": {
+      "exit_code": 0,
+      "ok": true,
+      "stderr": "",
+      "stdout": "\n\u250c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2510\n\u2502                 \u2695 Hermes Agent Status                  \u2502\n\u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518\n\n\u25c6 Environment\n  Project:      /home/cbmagent/.hermes/hermes-agent\n  Python:       3.11.15\n  .env file:    \u2713 exists\n  Model:        gpt-5.5\n  Provider:     OpenAI Codex\n\n\u25c6 API Keys\n  OpenRouter    \u2717 (not set)\n  OpenAI        \u2717 (not set)\n  NVIDIA        \u2717 (not set)\n  Z.AI/GLM      \u2717 (not set)\n  Kimi          \u2717 (not set)\n  StepFun Step Plan  \u2717 (not set)\n  MiniMax       \u2717 (not set)\n  MiniMax-CN    \u2717 (not set)\n  Firecrawl     \u2717 (not set)\n  Tavily        \u2717 (not set)\n  Browser Use   \u2717 (not set)\n  Browserbase   \u2717 (not set)\n  FAL           \u2717 (not set)\n  Tinker        \u2717 (not set)\n  WandB         \u2717 (not set)\n  ElevenLabs    \u2717 (not set)\n  GitHub        \u2717 (not set)\n  Anthropic     \u2717 (not set)\n\n\u25c6 Auth Providers\n  Nous Portal   \u2713 logged in\n    Portal URL: https://portal.nousresearch.com\n    Access exp: 2026-05-03 17:40:51 EDT\n    Key exp:    2026-05-04 15:53:41 EDT\n    Refresh:    yes\n  OpenAI Codex  \u2713 logged in\n    Auth file:  /home/cbmagent/.hermes/auth.json\n    Refreshed:  2026-05-03 16:14:31 EDT\n  Qwen OAuth    \u2717 not logged in (run: qwen auth qwen-oauth)\n    Auth file:  /home/cbmagent/.qwen/oauth_creds.json\n    Error:      Qwen CLI credentials not found. Run 'qwen auth qwen-oauth' first.\n  MiniMax OAuth  \u2717 not logged in (run: hermes auth add minimax-oauth)\n\n\u25c6 Nous Tool Gateway\n  Nous Portal   \u2713 managed tools available\n  Web tools       \u2713 included by subscription, not currently selected\n  Image generation \u2713 active via Nous subscription\n  OpenAI TTS      \u2713 active via Edge TTS\n  Browser automation \u2713 active via Nous subscription\n  Modal execution \u2713 active via local\n\n\u25c6 API-Key Providers\n  Z.AI / GLM       \u2717 not configured (run: hermes model)\n  Kimi / Moonshot  \u2717 not configured (run: hermes model)\n  StepFun Step Plan \u2717 not configured (run: hermes model)\n  MiniMax          \u2717 not configured (run: hermes model)\n  MiniMax (China)  \u2717 not configured (run: hermes model)\n\n\u25c6 Terminal Backend\n  Backend:      local\n  Sudo:         \u2717 disabled\n\n\u25c6 Messaging Platforms\n  Telegram      \u2713 configured (home: 8742801497)\n  Discord       \u2717 not configured\n  WhatsApp      \u2717 not configured\n  Signal        \u2717 not configured\n  Slack         \u2717 not configured\n  Email         \u2717 not configured\n  SMS           \u2717 not configured\n  DingTalk      \u2717 not configured\n  Feishu        \u2717 not configured\n  WeCom         \u2717 not configured\n  WeCom Callback  \u2717 not configured\n  Weixin        \u2717 not configured\n  BlueBubbles   \u2717 not configured\n  QQBot         \u2717 not configured\n  Yuanbao       \u2717 not configured\n\n\u25c6 Gateway Service\n  Status:       \u2713 running\n  Manager:      systemd (user)\n  PID(s):       31463\n\n\u25c6 Scheduled Jobs\n  Jobs:         0\n\n\u25c6 Sessions\n  Active:       1 session(s)\n\n\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n  Run 'hermes doctor' for detailed diagnostics\n  Run 'hermes setup' to configure\n\n"
+    },
+    "recent_brain_actions_runs": {
+      "exit_code": 0,
+      "ok": true,
+      "stderr": "",
+      "stdout": ""
+    }
+  },
+  "generated_at_utc": "2026-05-03T21-36-23Z",
+  "notes": [
+    "OpenAI Codex OAuth/ChatGPT subscription quota is opaque from CLI; report observed failures/cooldowns rather than claiming exact remaining quota.",
+    "Provider routing recommendations should prefer read-only/local/GitHub Actions tasks when premium model quota appears constrained."
+  ],
+  "redacted": true,
+  "services": {
+    "openclaw_gateway_root": {
+      "body_head": "<!doctype html>\n<html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\" />\n    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\" />\n    <title>OpenClaw Control</title>\n    <meta name=\"color-scheme\" content=\"dark light\" />\n    <link rel=\"icon\" type=\"image/svg+xml\" href=\"./favicon.svg\" />\n    <link rel=\"icon\" type=\"image/png\" sizes=\"32x32\" href=\"./favicon-32.png\" />\n    <link rel=\"apple-touch-icon\" sizes=\"180x180\" href=\"./apple-touch-icon.png\" />\n    <link rel=\"manifest\" href=\"mani",
+      "ok": true,
+      "status": 200
+    },
+    "openclaw_models": {
+      "body_head": "<!doctype html>\n<html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\" />\n    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\" />\n    <title>OpenClaw Control</title>\n    <meta name=\"color-scheme\" content=\"dark light\" />\n    <link rel=\"icon\" type=\"image/svg+xml\" href=\"./favicon.svg\" />\n    <link rel=\"icon\" type=\"image/png\" sizes=\"32x32\" href=\"./favicon-32.png\" />\n    <link rel=\"apple-touch-icon\" sizes=\"180x180\" href=\"./apple-touch-icon.png\" />\n    <link rel=\"manifest\" href=\"mani",
+      "ok": true,
+      "status": 200
+    }
+  },
+  "signals": {
+    "hermes_agent_log": [
+      "2026-05-03 16:15:00,792 INFO hermes_cli.plugins: Plugin 'openai-codex' registered image_gen provider: openai-codex",
+      "2026-05-03 16:15:00,793 INFO hermes_cli.plugins: Plugin 'xai' registered image_gen provider: xai",
+      "2026-05-03 16:15:05,848 INFO agent.auxiliary_client: Vision auto-detect: using main provider openai-codex (gpt-5.5)",
+      "2026-05-03 16:15:06,244 INFO agent.auxiliary_client: Vision auto-detect: using main provider openai-codex (gpt-5.5)",
+      "2026-05-03 16:15:07,165 INFO agent.auxiliary_client: Auxiliary auto-detect: using main provider openai-codex (gpt-5.5)",
+      "2026-05-03 16:18:00,179 INFO [20260503_150903_d1cc7c] agent.auxiliary_client: Vision auto-detect: using main provider openai-codex (gpt-5.5)",
+      "2026-05-03 16:18:00,207 INFO [20260503_150903_d1cc7c] agent.auxiliary_client: Auxiliary auto-detect: using main provider openai-codex (gpt-5.5)",
+      "2026-05-03 16:18:44,606 INFO [20260503_155326_4b62db] agent.auxiliary_client: Auxiliary auto-detect: using main provider openai-codex (gpt-5.5)",
+      "2026-05-03 16:18:44,616 INFO [20260503_155326_4b62db] agent.auxiliary_client: Auxiliary auto-detect: using main provider openai-codex (gpt-5.5)",
+      "2026-05-03 16:18:44,626 INFO [20260503_155326_4b62db] agent.auxiliary_client: Auxiliary auto-detect: using main provider openai-codex (gpt-5.5)",
+      "2026-05-03 16:18:44,636 INFO [20260503_155326_4b62db] agent.auxiliary_client: Auxiliary auto-detect: using main provider openai-codex (gpt-5.5)",
+      "2026-05-03 16:18:44,648 INFO [20260503_155326_4b62db] agent.auxiliary_client: Auxiliary auto-detect: using main provider openai-codex (gpt-5.5)",
+      "2026-05-03 16:18:44,661 INFO [20260503_155326_4b62db] agent.auxiliary_client: Auxiliary auto-detect: using main provider openai-codex (gpt-5.5)",
+      "2026-05-03 16:18:44,674 INFO [20260503_155326_4b62db] agent.auxiliary_client: Auxiliary auto-detect: using main provider openai-codex (gpt-5.5)",
+      "2026-05-03 16:42:44,777 ERROR tools.vision_tools: Error analyzing image: Invalid image source. Provide an HTTP/HTTPS URL or a valid local file path.",
+      "    raise ValueError(",
+      "ValueError: Invalid image source. Provide an HTTP/HTTPS URL or a valid local file path.",
+      "2026-05-03 16:51:23,496 INFO [20260503_155326_4b62db] agent.auxiliary_client: Auxiliary auto-detect: using main provider openai-codex (gpt-5.5)",
+      "2026-05-03 16:57:07,398 INFO agent.auxiliary_client: Auxiliary auto-detect: using main provider openai-codex (gpt-5.5)",
+      "2026-05-03 17:25:50,280 INFO agent.auxiliary_client: Auxiliary auto-detect: using main provider openai-codex (gpt-5.5)"
+    ],
+    "hermes_gateway_log": [
+      "2026-05-03 02:13:22,974 WARNING gateway.platforms.telegram: [Telegram] Connect attempt 1/8 failed: httpx.ConnectError: All connection attempts failed \u2014 retrying in 1s",
+      "2026-05-03 02:13:23,979 WARNING gateway.platforms.telegram: [Telegram] Connect attempt 2/8 failed: httpx.ConnectError: All connection attempts failed \u2014 retrying in 2s",
+      "2026-05-03 10:17:06,471 WARNING gateway.platforms.telegram: [Telegram] Connect attempt 1/8 failed: httpx.ConnectError: All connection attempts failed \u2014 retrying in 1s",
+      "2026-05-03 10:17:07,475 WARNING gateway.platforms.telegram: [Telegram] Connect attempt 2/8 failed: httpx.ConnectError: All connection attempts failed \u2014 retrying in 2s",
+      "2026-05-03 14:29:23,757 WARNING gateway.platforms.telegram: [Telegram] Telegram network error, scheduling reconnect: httpx.ReadError: ",
+      "2026-05-03 14:29:23,757 WARNING gateway.platforms.telegram: [Telegram] Telegram network error (attempt 1/10), reconnecting in 5s. Error: httpx.ReadError: ",
+      "2026-05-03 14:29:30,125 INFO gateway.platforms.telegram: [Telegram] Telegram polling resumed after network error (attempt 1)",
+      "2026-05-03 15:04:18,542 INFO gateway.run: inbound message: platform=telegram user=cbm agent chat=8742801497 msg='Im getting this error on my session with openclaw \u26a0\ufe0f Something went wrong while '"
+    ]
+  }
+}

--- a/reports/provider-usage/2026-05-03T21-36-23Z.md
+++ b/reports/provider-usage/2026-05-03T21-36-23Z.md
@@ -1,0 +1,74 @@
+# Provider Usage and Health Report
+
+Generated UTC: `2026-05-03T21-36-23Z`
+
+This report is redacted. It does not intentionally print tokens, API keys, bearer values, or credential files.
+
+## Summary
+
+- Hermes status command: `ok`
+- OpenClaw gateway root: `ok` 200
+- GitHub CLI auth: `ok`
+
+## Current Config Signals
+
+```text
+◆ Model
+  Model:        {'default': 'gpt-5.5', 'provider': 'openai-codex'}
+  Model:        (auto)
+
+```
+
+## Auth/Provider Names
+
+```text
+copilot (1 credentials):
+  #1  gh auth [REDACTED]
+
+nous (1 credentials):
+  #1  device_code          oauth   device_code ←
+
+openai-codex (1 credentials):
+  #1  openai-codex-oauth-1 oauth   device_code ←
+
+
+```
+
+## Recent GitHub Actions
+
+```text
+No runs found or command unavailable.
+```
+
+## Recent Rate Limit / Cooldown Signals
+
+### hermes_agent_log
+
+- `2026-05-03 16:18:44,636 INFO [20260503_155326_4b62db] agent.auxiliary_client: Auxiliary auto-detect: using main provider openai-codex (gpt-5.5)`
+- `2026-05-03 16:18:44,648 INFO [20260503_155326_4b62db] agent.auxiliary_client: Auxiliary auto-detect: using main provider openai-codex (gpt-5.5)`
+- `2026-05-03 16:18:44,661 INFO [20260503_155326_4b62db] agent.auxiliary_client: Auxiliary auto-detect: using main provider openai-codex (gpt-5.5)`
+- `2026-05-03 16:18:44,674 INFO [20260503_155326_4b62db] agent.auxiliary_client: Auxiliary auto-detect: using main provider openai-codex (gpt-5.5)`
+- `2026-05-03 16:42:44,777 ERROR tools.vision_tools: Error analyzing image: Invalid image source. Provide an HTTP/HTTPS URL or a valid local file path.`
+- `    raise ValueError(`
+- `ValueError: Invalid image source. Provide an HTTP/HTTPS URL or a valid local file path.`
+- `2026-05-03 16:51:23,496 INFO [20260503_155326_4b62db] agent.auxiliary_client: Auxiliary auto-detect: using main provider openai-codex (gpt-5.5)`
+- `2026-05-03 16:57:07,398 INFO agent.auxiliary_client: Auxiliary auto-detect: using main provider openai-codex (gpt-5.5)`
+- `2026-05-03 17:25:50,280 INFO agent.auxiliary_client: Auxiliary auto-detect: using main provider openai-codex (gpt-5.5)`
+
+### hermes_gateway_log
+
+- `2026-05-03 02:13:22,974 WARNING gateway.platforms.telegram: [Telegram] Connect attempt 1/8 failed: httpx.ConnectError: All connection attempts failed — retrying in 1s`
+- `2026-05-03 02:13:23,979 WARNING gateway.platforms.telegram: [Telegram] Connect attempt 2/8 failed: httpx.ConnectError: All connection attempts failed — retrying in 2s`
+- `2026-05-03 10:17:06,471 WARNING gateway.platforms.telegram: [Telegram] Connect attempt 1/8 failed: httpx.ConnectError: All connection attempts failed — retrying in 1s`
+- `2026-05-03 10:17:07,475 WARNING gateway.platforms.telegram: [Telegram] Connect attempt 2/8 failed: httpx.ConnectError: All connection attempts failed — retrying in 2s`
+- `2026-05-03 14:29:23,757 WARNING gateway.platforms.telegram: [Telegram] Telegram network error, scheduling reconnect: httpx.ReadError: `
+- `2026-05-03 14:29:23,757 WARNING gateway.platforms.telegram: [Telegram] Telegram network error (attempt 1/10), reconnecting in 5s. Error: httpx.ReadError: `
+- `2026-05-03 14:29:30,125 INFO gateway.platforms.telegram: [Telegram] Telegram polling resumed after network error (attempt 1)`
+- `2026-05-03 15:04:18,542 INFO gateway.run: inbound message: platform=telegram user=cbm agent chat=8742801497 msg='Im getting this error on my session with openclaw ⚠️ Something went wrong while '`
+
+## Recommendations
+
+- Treat OpenAI Codex OAuth quota as opaque; monitor observed rate-limit/cooldown errors.
+- Use Nous/OpenClaw/local tools as fallback/specialists when primary provider signals failures.
+- Keep deterministic audits in scripts/GitHub Actions so premium model quota is reserved for reasoning/coding.
+- Add scheduled provider report workflow after read-only environment design is finalized.

--- a/reports/provider-usage/latest.json
+++ b/reports/provider-usage/latest.json
@@ -1,0 +1,86 @@
+{
+  "commands": {
+    "gh_auth_status": {
+      "exit_code": 0,
+      "ok": true,
+      "stderr": "",
+      "stdout": "github.com\n  \u2713 Logged in to github.com account cbmagent (keyring)\n  - Active account: true\n  - Git operations protocol: https\n  - Token: [REDACTED]\n  - Token scopes: 'admin:enterprise', 'admin:gpg_key', 'admin:org', 'admin:org_hook', 'admin:public_key', 'admin:repo_hook', 'admin:ssh_signing_key', 'audit_log', 'codespace', 'copilot', 'delete:packages', 'delete_repo', 'gist', 'notifications', 'project', 'repo', 'user', 'workflow', 'write:discussion', 'write:network_configurations', 'write:packages'\n\n  \u2713 Logged in to github.com account clarkemoyer (/home/cbmagent/.config/gh/hosts.yml)\n  - Active account: false\n  - Git operations protocol: https\n  - Token: [REDACTED]\n  - Token scopes: 'gist', 'read:org', 'repo', 'workflow'\n"
+    },
+    "hermes_auth_list_names_only": {
+      "exit_code": 0,
+      "ok": true,
+      "stderr": "",
+      "stdout": "copilot (1 credentials):\n  #1  gh auth [REDACTED]\n\nnous (1 credentials):\n  #1  device_code          oauth   device_code \u2190\n\nopenai-codex (1 credentials):\n  #1  openai-codex-oauth-1 oauth   device_code \u2190\n\n"
+    },
+    "hermes_config_provider_model": {
+      "exit_code": 0,
+      "ok": true,
+      "stderr": "",
+      "stdout": "\u25c6 Model\n  Model:        {'default': 'gpt-5.5', 'provider': 'openai-codex'}\n  Model:        (auto)\n"
+    },
+    "hermes_status": {
+      "exit_code": 0,
+      "ok": true,
+      "stderr": "",
+      "stdout": "\n\u250c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2510\n\u2502                 \u2695 Hermes Agent Status                  \u2502\n\u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518\n\n\u25c6 Environment\n  Project:      /home/cbmagent/.hermes/hermes-agent\n  Python:       3.11.15\n  .env file:    \u2713 exists\n  Model:        gpt-5.5\n  Provider:     OpenAI Codex\n\n\u25c6 API Keys\n  OpenRouter    \u2717 (not set)\n  OpenAI        \u2717 (not set)\n  NVIDIA        \u2717 (not set)\n  Z.AI/GLM      \u2717 (not set)\n  Kimi          \u2717 (not set)\n  StepFun Step Plan  \u2717 (not set)\n  MiniMax       \u2717 (not set)\n  MiniMax-CN    \u2717 (not set)\n  Firecrawl     \u2717 (not set)\n  Tavily        \u2717 (not set)\n  Browser Use   \u2717 (not set)\n  Browserbase   \u2717 (not set)\n  FAL           \u2717 (not set)\n  Tinker        \u2717 (not set)\n  WandB         \u2717 (not set)\n  ElevenLabs    \u2717 (not set)\n  GitHub        \u2717 (not set)\n  Anthropic     \u2717 (not set)\n\n\u25c6 Auth Providers\n  Nous Portal   \u2713 logged in\n    Portal URL: https://portal.nousresearch.com\n    Access exp: 2026-05-03 17:40:51 EDT\n    Key exp:    2026-05-04 15:53:41 EDT\n    Refresh:    yes\n  OpenAI Codex  \u2713 logged in\n    Auth file:  /home/cbmagent/.hermes/auth.json\n    Refreshed:  2026-05-03 16:14:31 EDT\n  Qwen OAuth    \u2717 not logged in (run: qwen auth qwen-oauth)\n    Auth file:  /home/cbmagent/.qwen/oauth_creds.json\n    Error:      Qwen CLI credentials not found. Run 'qwen auth qwen-oauth' first.\n  MiniMax OAuth  \u2717 not logged in (run: hermes auth add minimax-oauth)\n\n\u25c6 Nous Tool Gateway\n  Nous Portal   \u2713 managed tools available\n  Web tools       \u2713 included by subscription, not currently selected\n  Image generation \u2713 active via Nous subscription\n  OpenAI TTS      \u2713 active via Edge TTS\n  Browser automation \u2713 active via Nous subscription\n  Modal execution \u2713 active via local\n\n\u25c6 API-Key Providers\n  Z.AI / GLM       \u2717 not configured (run: hermes model)\n  Kimi / Moonshot  \u2717 not configured (run: hermes model)\n  StepFun Step Plan \u2717 not configured (run: hermes model)\n  MiniMax          \u2717 not configured (run: hermes model)\n  MiniMax (China)  \u2717 not configured (run: hermes model)\n\n\u25c6 Terminal Backend\n  Backend:      local\n  Sudo:         \u2717 disabled\n\n\u25c6 Messaging Platforms\n  Telegram      \u2713 configured (home: 8742801497)\n  Discord       \u2717 not configured\n  WhatsApp      \u2717 not configured\n  Signal        \u2717 not configured\n  Slack         \u2717 not configured\n  Email         \u2717 not configured\n  SMS           \u2717 not configured\n  DingTalk      \u2717 not configured\n  Feishu        \u2717 not configured\n  WeCom         \u2717 not configured\n  WeCom Callback  \u2717 not configured\n  Weixin        \u2717 not configured\n  BlueBubbles   \u2717 not configured\n  QQBot         \u2717 not configured\n  Yuanbao       \u2717 not configured\n\n\u25c6 Gateway Service\n  Status:       \u2713 running\n  Manager:      systemd (user)\n  PID(s):       31463\n\n\u25c6 Scheduled Jobs\n  Jobs:         0\n\n\u25c6 Sessions\n  Active:       1 session(s)\n\n\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n  Run 'hermes doctor' for detailed diagnostics\n  Run 'hermes setup' to configure\n\n"
+    },
+    "recent_brain_actions_runs": {
+      "exit_code": 0,
+      "ok": true,
+      "stderr": "",
+      "stdout": ""
+    }
+  },
+  "generated_at_utc": "2026-05-03T21-36-23Z",
+  "notes": [
+    "OpenAI Codex OAuth/ChatGPT subscription quota is opaque from CLI; report observed failures/cooldowns rather than claiming exact remaining quota.",
+    "Provider routing recommendations should prefer read-only/local/GitHub Actions tasks when premium model quota appears constrained."
+  ],
+  "redacted": true,
+  "services": {
+    "openclaw_gateway_root": {
+      "body_head": "<!doctype html>\n<html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\" />\n    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\" />\n    <title>OpenClaw Control</title>\n    <meta name=\"color-scheme\" content=\"dark light\" />\n    <link rel=\"icon\" type=\"image/svg+xml\" href=\"./favicon.svg\" />\n    <link rel=\"icon\" type=\"image/png\" sizes=\"32x32\" href=\"./favicon-32.png\" />\n    <link rel=\"apple-touch-icon\" sizes=\"180x180\" href=\"./apple-touch-icon.png\" />\n    <link rel=\"manifest\" href=\"mani",
+      "ok": true,
+      "status": 200
+    },
+    "openclaw_models": {
+      "body_head": "<!doctype html>\n<html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\" />\n    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\" />\n    <title>OpenClaw Control</title>\n    <meta name=\"color-scheme\" content=\"dark light\" />\n    <link rel=\"icon\" type=\"image/svg+xml\" href=\"./favicon.svg\" />\n    <link rel=\"icon\" type=\"image/png\" sizes=\"32x32\" href=\"./favicon-32.png\" />\n    <link rel=\"apple-touch-icon\" sizes=\"180x180\" href=\"./apple-touch-icon.png\" />\n    <link rel=\"manifest\" href=\"mani",
+      "ok": true,
+      "status": 200
+    }
+  },
+  "signals": {
+    "hermes_agent_log": [
+      "2026-05-03 16:15:00,792 INFO hermes_cli.plugins: Plugin 'openai-codex' registered image_gen provider: openai-codex",
+      "2026-05-03 16:15:00,793 INFO hermes_cli.plugins: Plugin 'xai' registered image_gen provider: xai",
+      "2026-05-03 16:15:05,848 INFO agent.auxiliary_client: Vision auto-detect: using main provider openai-codex (gpt-5.5)",
+      "2026-05-03 16:15:06,244 INFO agent.auxiliary_client: Vision auto-detect: using main provider openai-codex (gpt-5.5)",
+      "2026-05-03 16:15:07,165 INFO agent.auxiliary_client: Auxiliary auto-detect: using main provider openai-codex (gpt-5.5)",
+      "2026-05-03 16:18:00,179 INFO [20260503_150903_d1cc7c] agent.auxiliary_client: Vision auto-detect: using main provider openai-codex (gpt-5.5)",
+      "2026-05-03 16:18:00,207 INFO [20260503_150903_d1cc7c] agent.auxiliary_client: Auxiliary auto-detect: using main provider openai-codex (gpt-5.5)",
+      "2026-05-03 16:18:44,606 INFO [20260503_155326_4b62db] agent.auxiliary_client: Auxiliary auto-detect: using main provider openai-codex (gpt-5.5)",
+      "2026-05-03 16:18:44,616 INFO [20260503_155326_4b62db] agent.auxiliary_client: Auxiliary auto-detect: using main provider openai-codex (gpt-5.5)",
+      "2026-05-03 16:18:44,626 INFO [20260503_155326_4b62db] agent.auxiliary_client: Auxiliary auto-detect: using main provider openai-codex (gpt-5.5)",
+      "2026-05-03 16:18:44,636 INFO [20260503_155326_4b62db] agent.auxiliary_client: Auxiliary auto-detect: using main provider openai-codex (gpt-5.5)",
+      "2026-05-03 16:18:44,648 INFO [20260503_155326_4b62db] agent.auxiliary_client: Auxiliary auto-detect: using main provider openai-codex (gpt-5.5)",
+      "2026-05-03 16:18:44,661 INFO [20260503_155326_4b62db] agent.auxiliary_client: Auxiliary auto-detect: using main provider openai-codex (gpt-5.5)",
+      "2026-05-03 16:18:44,674 INFO [20260503_155326_4b62db] agent.auxiliary_client: Auxiliary auto-detect: using main provider openai-codex (gpt-5.5)",
+      "2026-05-03 16:42:44,777 ERROR tools.vision_tools: Error analyzing image: Invalid image source. Provide an HTTP/HTTPS URL or a valid local file path.",
+      "    raise ValueError(",
+      "ValueError: Invalid image source. Provide an HTTP/HTTPS URL or a valid local file path.",
+      "2026-05-03 16:51:23,496 INFO [20260503_155326_4b62db] agent.auxiliary_client: Auxiliary auto-detect: using main provider openai-codex (gpt-5.5)",
+      "2026-05-03 16:57:07,398 INFO agent.auxiliary_client: Auxiliary auto-detect: using main provider openai-codex (gpt-5.5)",
+      "2026-05-03 17:25:50,280 INFO agent.auxiliary_client: Auxiliary auto-detect: using main provider openai-codex (gpt-5.5)"
+    ],
+    "hermes_gateway_log": [
+      "2026-05-03 02:13:22,974 WARNING gateway.platforms.telegram: [Telegram] Connect attempt 1/8 failed: httpx.ConnectError: All connection attempts failed \u2014 retrying in 1s",
+      "2026-05-03 02:13:23,979 WARNING gateway.platforms.telegram: [Telegram] Connect attempt 2/8 failed: httpx.ConnectError: All connection attempts failed \u2014 retrying in 2s",
+      "2026-05-03 10:17:06,471 WARNING gateway.platforms.telegram: [Telegram] Connect attempt 1/8 failed: httpx.ConnectError: All connection attempts failed \u2014 retrying in 1s",
+      "2026-05-03 10:17:07,475 WARNING gateway.platforms.telegram: [Telegram] Connect attempt 2/8 failed: httpx.ConnectError: All connection attempts failed \u2014 retrying in 2s",
+      "2026-05-03 14:29:23,757 WARNING gateway.platforms.telegram: [Telegram] Telegram network error, scheduling reconnect: httpx.ReadError: ",
+      "2026-05-03 14:29:23,757 WARNING gateway.platforms.telegram: [Telegram] Telegram network error (attempt 1/10), reconnecting in 5s. Error: httpx.ReadError: ",
+      "2026-05-03 14:29:30,125 INFO gateway.platforms.telegram: [Telegram] Telegram polling resumed after network error (attempt 1)",
+      "2026-05-03 15:04:18,542 INFO gateway.run: inbound message: platform=telegram user=cbm agent chat=8742801497 msg='Im getting this error on my session with openclaw \u26a0\ufe0f Something went wrong while '"
+    ]
+  }
+}

--- a/reports/provider-usage/latest.md
+++ b/reports/provider-usage/latest.md
@@ -1,0 +1,74 @@
+# Provider Usage and Health Report
+
+Generated UTC: `2026-05-03T21-36-23Z`
+
+This report is redacted. It does not intentionally print tokens, API keys, bearer values, or credential files.
+
+## Summary
+
+- Hermes status command: `ok`
+- OpenClaw gateway root: `ok` 200
+- GitHub CLI auth: `ok`
+
+## Current Config Signals
+
+```text
+◆ Model
+  Model:        {'default': 'gpt-5.5', 'provider': 'openai-codex'}
+  Model:        (auto)
+
+```
+
+## Auth/Provider Names
+
+```text
+copilot (1 credentials):
+  #1  gh auth [REDACTED]
+
+nous (1 credentials):
+  #1  device_code          oauth   device_code ←
+
+openai-codex (1 credentials):
+  #1  openai-codex-oauth-1 oauth   device_code ←
+
+
+```
+
+## Recent GitHub Actions
+
+```text
+No runs found or command unavailable.
+```
+
+## Recent Rate Limit / Cooldown Signals
+
+### hermes_agent_log
+
+- `2026-05-03 16:18:44,636 INFO [20260503_155326_4b62db] agent.auxiliary_client: Auxiliary auto-detect: using main provider openai-codex (gpt-5.5)`
+- `2026-05-03 16:18:44,648 INFO [20260503_155326_4b62db] agent.auxiliary_client: Auxiliary auto-detect: using main provider openai-codex (gpt-5.5)`
+- `2026-05-03 16:18:44,661 INFO [20260503_155326_4b62db] agent.auxiliary_client: Auxiliary auto-detect: using main provider openai-codex (gpt-5.5)`
+- `2026-05-03 16:18:44,674 INFO [20260503_155326_4b62db] agent.auxiliary_client: Auxiliary auto-detect: using main provider openai-codex (gpt-5.5)`
+- `2026-05-03 16:42:44,777 ERROR tools.vision_tools: Error analyzing image: Invalid image source. Provide an HTTP/HTTPS URL or a valid local file path.`
+- `    raise ValueError(`
+- `ValueError: Invalid image source. Provide an HTTP/HTTPS URL or a valid local file path.`
+- `2026-05-03 16:51:23,496 INFO [20260503_155326_4b62db] agent.auxiliary_client: Auxiliary auto-detect: using main provider openai-codex (gpt-5.5)`
+- `2026-05-03 16:57:07,398 INFO agent.auxiliary_client: Auxiliary auto-detect: using main provider openai-codex (gpt-5.5)`
+- `2026-05-03 17:25:50,280 INFO agent.auxiliary_client: Auxiliary auto-detect: using main provider openai-codex (gpt-5.5)`
+
+### hermes_gateway_log
+
+- `2026-05-03 02:13:22,974 WARNING gateway.platforms.telegram: [Telegram] Connect attempt 1/8 failed: httpx.ConnectError: All connection attempts failed — retrying in 1s`
+- `2026-05-03 02:13:23,979 WARNING gateway.platforms.telegram: [Telegram] Connect attempt 2/8 failed: httpx.ConnectError: All connection attempts failed — retrying in 2s`
+- `2026-05-03 10:17:06,471 WARNING gateway.platforms.telegram: [Telegram] Connect attempt 1/8 failed: httpx.ConnectError: All connection attempts failed — retrying in 1s`
+- `2026-05-03 10:17:07,475 WARNING gateway.platforms.telegram: [Telegram] Connect attempt 2/8 failed: httpx.ConnectError: All connection attempts failed — retrying in 2s`
+- `2026-05-03 14:29:23,757 WARNING gateway.platforms.telegram: [Telegram] Telegram network error, scheduling reconnect: httpx.ReadError: `
+- `2026-05-03 14:29:23,757 WARNING gateway.platforms.telegram: [Telegram] Telegram network error (attempt 1/10), reconnecting in 5s. Error: httpx.ReadError: `
+- `2026-05-03 14:29:30,125 INFO gateway.platforms.telegram: [Telegram] Telegram polling resumed after network error (attempt 1)`
+- `2026-05-03 15:04:18,542 INFO gateway.run: inbound message: platform=telegram user=cbm agent chat=8742801497 msg='Im getting this error on my session with openclaw ⚠️ Something went wrong while '`
+
+## Recommendations
+
+- Treat OpenAI Codex OAuth quota as opaque; monitor observed rate-limit/cooldown errors.
+- Use Nous/OpenClaw/local tools as fallback/specialists when primary provider signals failures.
+- Keep deterministic audits in scripts/GitHub Actions so premium model quota is reserved for reasoning/coding.
+- Add scheduled provider report workflow after read-only environment design is finalized.

--- a/scripts/provider-usage-report.py
+++ b/scripts/provider-usage-report.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Generate a redacted provider usage/health report.
+
+This script uses local CLI/status/log signals only. It must not print secrets.
+"""
+from __future__ import annotations
+import datetime as dt
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+from urllib.request import urlopen, Request
+from urllib.error import URLError
+
+OUT_DIR = Path('reports/provider-usage')
+SECRET_PATTERNS = [
+    re.compile(r'gho_[A-Za-z0-9_]+'),
+    re.compile(r'ghp_[A-Za-z0-9_]+'),
+    re.compile(r'github_pat_[A-Za-z0-9_]+'),
+    re.compile(r'(Bearer\s+)[A-Za-z0-9._\-]+', re.I),
+    re.compile(r'([A-Za-z0-9_]*token[A-Za-z0-9_]*\s*[:=]\s*)[^\s,}\]]+', re.I),
+    re.compile(r'([A-Za-z0-9_]*secret[A-Za-z0-9_]*\s*[:=]\s*)[^\s,}\]]+', re.I),
+    re.compile(r'([A-Za-z0-9_]*key[A-Za-z0-9_]*\s*[:=]\s*)[^\s,}\]]+', re.I),
+]
+
+def redact(s: str) -> str:
+    out = s
+    for pat in SECRET_PATTERNS:
+        out = pat.sub(lambda m: (m.group(1) if m.groups() else '') + '[REDACTED]', out)
+    return out
+
+def run(cmd: list[str], timeout=15) -> dict:
+    try:
+        p = subprocess.run(cmd, text=True, capture_output=True, timeout=timeout)
+        return {'ok': p.returncode == 0, 'exit_code': p.returncode, 'stdout': redact(p.stdout[-4000:]), 'stderr': redact(p.stderr[-4000:])}
+    except Exception as e:
+        return {'ok': False, 'error': type(e).__name__ + ': ' + str(e)}
+
+def http(url: str, timeout=5) -> dict:
+    try:
+        req = Request(url, headers={'User-Agent': 'cbmagent-provider-report/0.1'})
+        with urlopen(req, timeout=timeout) as resp:
+            body = resp.read(1000).decode('utf-8', 'ignore')
+            return {'ok': True, 'status': resp.status, 'body_head': redact(body[:500])}
+    except Exception as e:
+        return {'ok': False, 'error': type(e).__name__ + ': ' + str(e)}
+
+def grep_log(path: Path, terms: list[str], max_lines=20) -> list[str]:
+    if not path.exists():
+        return []
+    try:
+        lines = path.read_text(errors='ignore').splitlines()[-5000:]
+    except Exception:
+        return []
+    hits=[]
+    low_terms=[t.lower() for t in terms]
+    for line in lines:
+        lo=line.lower()
+        if any(t in lo for t in low_terms):
+            hits.append(redact(line)[-500:])
+    return hits[-max_lines:]
+
+def main() -> int:
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    ts = dt.datetime.now(dt.timezone.utc).strftime('%Y-%m-%dT%H-%M-%SZ')
+    data = {
+        'generated_at_utc': ts,
+        'redacted': True,
+        'commands': {},
+        'services': {},
+        'signals': {},
+        'notes': []
+    }
+    data['commands']['hermes_status'] = run(['hermes', 'status'], timeout=20)
+    data['commands']['hermes_config_provider_model'] = run(['bash','-lc','hermes config show 2>/dev/null | grep -E "Provider|Model|provider|model" || true'], timeout=20)
+    data['commands']['hermes_auth_list_names_only'] = run(['bash','-lc','hermes auth list 2>/dev/null | sed -E "s/(token|secret|key).*/[REDACTED]/Ig" || true'], timeout=20)
+    data['commands']['gh_auth_status'] = run(['gh','auth','status'], timeout=20)
+    data['commands']['recent_brain_actions_runs'] = run(['gh','run','list','--repo','cbmagent/cbmagent-brain','--limit','10'], timeout=20)
+    data['services']['openclaw_gateway_root'] = http('http://127.0.0.1:18789/', timeout=5)
+    data['services']['openclaw_models'] = http('http://127.0.0.1:18789/v1/models', timeout=5)
+    log_terms = ['rate limit','ratelimit','quota','cooldown','429','exhausted','unavailable','provider','error']
+    data['signals']['hermes_agent_log'] = grep_log(Path.home()/'.hermes/logs/agent.log', log_terms)
+    data['signals']['hermes_gateway_log'] = grep_log(Path.home()/'.hermes/logs/gateway.log', log_terms)
+    data['notes'].append('OpenAI Codex OAuth/ChatGPT subscription quota is opaque from CLI; report observed failures/cooldowns rather than claiming exact remaining quota.')
+    data['notes'].append('Provider routing recommendations should prefer read-only/local/GitHub Actions tasks when premium model quota appears constrained.')
+    json_path = OUT_DIR / f'{ts}.json'
+    md_path = OUT_DIR / f'{ts}.md'
+    latest_json = OUT_DIR / 'latest.json'
+    latest_md = OUT_DIR / 'latest.md'
+    json_text = json.dumps(data, indent=2, sort_keys=True) + '\n'
+    json_path.write_text(json_text, encoding='utf-8')
+    latest_json.write_text(json_text, encoding='utf-8')
+    lines = [
+        '# Provider Usage and Health Report', '',
+        f'Generated UTC: `{ts}`', '',
+        'This report is redacted. It does not intentionally print tokens, API keys, bearer values, or credential files.', '',
+        '## Summary', ''
+    ]
+    hs = data['commands']['hermes_status']
+    lines.append(f"- Hermes status command: `{'ok' if hs.get('ok') else 'not ok'}`")
+    oc = data['services']['openclaw_gateway_root']
+    lines.append(f"- OpenClaw gateway root: `{'ok' if oc.get('ok') else 'not ok'}` {oc.get('status','')}")
+    gh = data['commands']['gh_auth_status']
+    lines.append(f"- GitHub CLI auth: `{'ok' if gh.get('ok') else 'not ok'}`")
+    lines += ['', '## Current Config Signals', '', '```text', data['commands']['hermes_config_provider_model'].get('stdout','') or data['commands']['hermes_config_provider_model'].get('stderr',''), '```', '', '## Auth/Provider Names', '', '```text', data['commands']['hermes_auth_list_names_only'].get('stdout','') or data['commands']['hermes_auth_list_names_only'].get('stderr',''), '```', '', '## Recent GitHub Actions', '', '```text', data['commands']['recent_brain_actions_runs'].get('stdout','') or 'No runs found or command unavailable.', '```', '', '## Recent Rate Limit / Cooldown Signals', '']
+    for log_name, hits in data['signals'].items():
+        lines += [f'### {log_name}', '']
+        if not hits:
+            lines.append('- No recent matching signals found.')
+        else:
+            for h in hits[-10:]:
+                lines.append(f'- `{h}`')
+        lines.append('')
+    lines += ['## Recommendations', '', '- Treat OpenAI Codex OAuth quota as opaque; monitor observed rate-limit/cooldown errors.', '- Use Nous/OpenClaw/local tools as fallback/specialists when primary provider signals failures.', '- Keep deterministic audits in scripts/GitHub Actions so premium model quota is reserved for reasoning/coding.', '- Add scheduled provider report workflow after read-only environment design is finalized.', '']
+    md = '\n'.join(lines)
+    md_path.write_text(md, encoding='utf-8')
+    latest_md.write_text(md, encoding='utf-8')
+    print(md_path)
+    return 0
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary\n\n- Adds a redacted provider usage/health reporting script\n- Generates the first provider health report under reports/provider-usage/\n- Reports Hermes provider/model, auth provider names, OpenClaw gateway health, GitHub Actions state, and recent rate-limit/cooldown/error signals\n\n## Current Findings\n\n- Hermes current model/provider: openai-codex / gpt-5.5\n- OpenClaw gateway root responded 200\n- GitHub CLI auth is working\n- No exact OpenAI subscription quota is exposed; report correctly treats it as opaque/observed-signal based\n\n## Test / Verification Plan\n\n- [x] Ran scripts/provider-usage-report.py\n- [x] Confirmed report redacts token/key/secret-like strings\n- [x] No credential files are committed\n\nCloses #4