### PR TITLE
feat: add VS Code operator workspace tasks

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,12 @@
+{
+  "recommendations": [
+    "GitHub.vscode-pull-request-github",
+    "GitHub.vscode-github-actions",
+    "GitHub.copilot",
+    "GitHub.copilot-chat",
+    "DavidAnson.vscode-markdownlint",
+    "redhat.vscode-yaml",
+    "esbenp.prettier-vscode",
+    "ms-playwright.playwright"
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,47 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Hermes: status",
+      "type": "shell",
+      "command": "hermes status",
+      "problemMatcher": []
+    },
+    {
+      "label": "Hermes: auth list",
+      "type": "shell",
+      "command": "hermes auth list",
+      "problemMatcher": []
+    },
+    {
+      "label": "Brain: validate YAML",
+      "type": "shell",
+      "command": "python3 scripts/validate-yaml.py",
+      "problemMatcher": []
+    },
+    {
+      "label": "Brain: run read-only domain audit",
+      "type": "shell",
+      "command": "python3 scripts/domain-readonly-audit.py",
+      "problemMatcher": []
+    },
+    {
+      "label": "Brain: provider usage report",
+      "type": "shell",
+      "command": "python3 scripts/provider-usage-report.py",
+      "problemMatcher": []
+    },
+    {
+      "label": "GitHub: open issues",
+      "type": "shell",
+      "command": "gh issue list --repo cbmagent/cbmagent-brain --limit 30",
+      "problemMatcher": []
+    },
+    {
+      "label": "GitHub: open PRs",
+      "type": "shell",
+      "command": "gh pr list --repo cbmagent/cbmagent-brain --limit 30",
+      "problemMatcher": []
+    }
+  ]
+}

--- a/workspaces/README.md
+++ b/workspaces/README.md
@@ -1,19 +1,34 @@
 # cbmagent Operator Workspace
 
-Placeholder for the future VS Code multi-root workspace.
+Open `workspaces/cbmagent.code-workspace` in VS Code to use this repo as the local operator console.
 
-Planned roots:
+## Intended Roots
 
-- cbmagent-brain
-- clarkemoyer.com
-- technologyadoptionbarriers.org
-- Free For Charity source templates as needed
-- selected site repos as they are created/migrated
+- `cbmagent-brain`
+- `clarkemoyer.com`
+- `technologyadoptionbarriers.org`
+- `FFC-IN-FFC_Single_Page_Template`
+- `FFC-IN-Footer_Only_Template`
+- `FFC-Cloudflare-Automation`
 
-Planned terminal/tasks:
+Some roots may not exist locally yet. Clone them as needed.
 
-- Hermes status
-- provider usage report
-- DNS/Pages read-only audit
-- GitHub issue/PR portfolio status
-- site health checks
+## Recommended Extensions
+
+See `.vscode/extensions.json`.
+
+## Useful Tasks
+
+Run VS Code command **Tasks: Run Task** and select:
+
+- `Hermes: status`
+- `Hermes: auth list`
+- `Brain: validate YAML`
+- `Brain: run read-only domain audit`
+- `Brain: provider usage report`
+- `GitHub: open issues`
+- `GitHub: open PRs`
+
+## Operating Model
+
+Use VS Code as an operator cockpit, not as a replacement for GitHub. Repo-specific work still follows issue → branch → PR → checks/review → merge.

--- a/workspaces/cbmagent.code-workspace
+++ b/workspaces/cbmagent.code-workspace
@@ -7,11 +7,30 @@
     {
       "name": "clarkemoyer.com",
       "path": "../../clarkemoyer.com"
+    },
+    {
+      "name": "technologyadoptionbarriers.org (clone when local)",
+      "path": "../../technologyadoptionbarriers.org"
+    },
+    {
+      "name": "FFC Single Page Template (clone when local)",
+      "path": "../../FFC-IN-FFC_Single_Page_Template"
+    },
+    {
+      "name": "FFC Footer Only Template (clone when local)",
+      "path": "../../FFC-IN-Footer_Only_Template"
+    },
+    {
+      "name": "FFC Cloudflare Automation (clone when local)",
+      "path": "../../FFC-Cloudflare-Automation"
     }
   ],
   "settings": {
     "terminal.integrated.defaultProfile.linux": "bash",
-    "git.autofetch": true
+    "git.autofetch": true,
+    "files.exclude": {
+      "**/.git": false
+    }
   },
   "extensions": {
     "recommendations": [


### PR DESCRIPTION
## Summary\n\n- Adds recommended VS Code extensions\n- Adds tasks for Hermes status/auth, YAML validation, domain audit, provider usage report, and GitHub issue/PR status\n- Expands the multi-root operator workspace to include brain, site, TABS, and Free For Charity source repos\n- Updates workspace README with usage guidance\n\n## Test / Verification Plan\n\n- [x] Validated .vscode/tasks.json with python -m json.tool\n- [x] Validated .vscode/extensions.json with python -m json.tool\n- [x] Validated workspaces/cbmagent.code-workspace with python -m json.tool\n\nCloses #5