### PR TITLE
docs: add read-only/write-gated environment rollout

### DIFF
--- a/docs/environment-rollout-checklist.md
+++ b/docs/environment-rollout-checklist.md
@@ -1,0 +1,146 @@
+# Read-Only and Write-Gated Environment Rollout Checklist
+
+This checklist enables maximum agent autonomy for read-only discovery while keeping production mutations human-gated.
+
+## Environment Names
+
+### Cloudflare
+
+- `cloudflare-readonly`
+- `cloudflare-prod`
+
+### Microsoft
+
+- `m365-readonly`
+- `m365-prod`
+
+### Google
+
+- `google-readonly`
+- `google-prod`
+
+### GitHub
+
+- default `GITHUB_TOKEN` read permissions for safe repo/issue/status reads
+- `github-prod` only when sensitive repo mutations need environment approval
+
+## Permission Model
+
+### Read-only environments
+
+Read-only environments should not require human approval once credentials are properly scoped. They may run on schedule, workflow dispatch, issue events, or agent request.
+
+Allowed examples:
+
+- list Cloudflare zones and DNS records
+- inspect Cloudflare redirects/rules
+- check DNS compliance and GitHub Pages readiness
+- list Microsoft domains and DKIM status
+- inspect Google Search Console/Analytics/Workspace status where scoped
+- list GitHub issues, PRs, workflow runs, and Pages status
+- upload artifacts and comment read-only findings on issues
+
+### Write-gated environments
+
+Write-capable environments require GitHub environment protection with required reviewers.
+
+Examples:
+
+- edit Cloudflare DNS records
+- create/update Cloudflare redirects
+- GitHub Pages cutover records
+- Microsoft domain add/verify/DKIM mutations
+- Google Workspace/Admin/Search Console property mutations
+- GitHub repo transfer, visibility, secrets, environments, branch protections, rulesets
+
+## Human Setup Tasks
+
+Clarke or an authorized admin needs to create/approve these outside the agent:
+
+### Cloudflare read-only
+
+- [ ] Create Cloudflare API token with least-privilege read-only scopes.
+- [ ] Scope token to the required account/zones where possible.
+- [ ] Add GitHub environment: `cloudflare-readonly`.
+- [ ] Add environment secret: `CM_CLOUDFLARE_API_TOKEN_READONLY`.
+- [ ] Do **not** require reviewers for read-only environment after scope is verified.
+
+Recommended minimum Cloudflare permissions:
+
+- Zone: Read
+- DNS: Read
+
+### Cloudflare production write
+
+- [ ] Create/confirm separate Cloudflare write token.
+- [ ] Add GitHub environment: `cloudflare-prod`.
+- [ ] Add secret: `CM_CLOUDFLARE_API_TOKEN_DNS_WRITE`.
+- [ ] Enable required reviewers.
+- [ ] Keep dry-run as default for workflows.
+
+Recommended Cloudflare write permissions:
+
+- Zone: Read
+- DNS: Edit
+- Additional write scopes only when a workflow proves it needs them.
+
+### Microsoft read-only
+
+- [ ] Create/read existing Entra app for read-only domain/status checks.
+- [ ] Prefer GitHub OIDC/federated credential over static secrets when practical.
+- [ ] Add environment: `m365-readonly`.
+- [ ] Add identifiers/secrets needed by the workflow.
+
+Likely Graph application permission:
+
+- Domain.Read.All or Directory.Read.All, with admin consent.
+
+### Microsoft production write
+
+- [ ] Create stricter write-capable app or expand only when needed.
+- [ ] Add environment: `m365-prod`.
+- [ ] Enable required reviewers.
+- [ ] Document exact Graph/Exchange permissions per workflow.
+
+### Google read-only
+
+- [ ] Create Google credential or workload identity path for read-only APIs.
+- [ ] Add environment: `google-readonly`.
+- [ ] Add only read-scoped credentials/secrets.
+
+Possible read scopes depend on selected APIs:
+
+- Search Console read-only
+- Google Analytics read-only
+- Drive metadata/read-only where needed
+- Workspace/Admin read-only where needed
+
+### Google production write
+
+- [ ] Create separate write-capable credential only if needed.
+- [ ] Add environment: `google-prod`.
+- [ ] Enable required reviewers.
+- [ ] Document exact scopes per workflow.
+
+## Workflow Design Rules
+
+1. Split every workflow into read-only and write-capable variants where possible.
+2. Read-only workflows should never import or reference write secrets.
+3. Write workflows should default to `dry_run: true`.
+4. Live writes require protected environment approval.
+5. Live writes should also require explicit inputs and/or approval labels.
+6. Workflows must post before/after summaries to the linked issue.
+7. Post-change verification should use read-only workflows.
+
+## Human Request Template
+
+When the agent needs Clarke, send a concise request:
+
+```text
+Human task needed: create/approve <environment/credential>.
+
+Purpose: <read-only audit or production write>.
+Required scope: <exact least-privilege permissions>.
+Where to add it: GitHub repo/org environment <name>, secret <name>.
+Why now: <workflow/issue blocked>.
+```

--- a/runbooks/environment-rollout.md
+++ b/runbooks/environment-rollout.md
@@ -1,0 +1,35 @@
+# Environment Rollout Runbook
+
+## Goal
+
+Give agents autonomous read-only inspection across Cloudflare, Microsoft, Google, and GitHub while requiring human approval for production writes.
+
+## Order of Operations
+
+1. Create read-only provider credentials first.
+2. Add read-only GitHub environments and secrets.
+3. Add read-only workflows and prove they cannot mutate state.
+4. Create write-capable environments separately.
+5. Add required reviewers to write-capable environments.
+6. Add dry-run-only write workflows.
+7. Add live mode only after dry-runs and approvals are proven.
+
+## Verification
+
+For each read-only workflow:
+
+- Confirm it succeeds without production write secrets.
+- Confirm it can run without environment approval.
+- Confirm it uploads/comment reports only.
+- Confirm it cannot call mutation endpoints.
+
+For each write workflow:
+
+- Confirm dry-run is default.
+- Confirm environment approval is required for live mode.
+- Confirm it comments before/after results.
+- Confirm post-change read-only verification runs.
+
+## Blockers
+
+The agent cannot create external provider credentials by itself. Clarke/admin action is required for Cloudflare, Microsoft, and Google credential setup.


### PR DESCRIPTION
## Summary\n\n- Adds environment rollout checklist for Cloudflare, Microsoft, Google, and GitHub\n- Documents read-only vs write-gated permission boundaries\n- Adds human setup task lists for scoped credentials and GitHub environments\n- Adds runbook for sequencing read-only autonomy before production writes\n\n## Test / Verification Plan\n\n- [x] Documentation reviewed\n- [x] No secrets or credentials included\n- [x] Human tasks are explicit and least-privilege oriented\n\nCloses #7