### PR TITLE
docs: add nonprofit giveback alignment tracker

### DIFF
--- a/portfolio/template-alignment.md
+++ b/portfolio/template-alignment.md
@@ -1,0 +1,51 @@
+# Template Alignment Tracker
+
+This tracker connects cbmagent portfolio work, Free For Charity source templates, and the advanced TABS reference implementation.
+
+## Source Repos
+
+| Repo | Role | Giveback Direction |
+| --- | --- | --- |
+| FreeForCharity/FFC-IN-FFC_Single_Page_Template | Default full Next.js nonprofit site template | Backport reusable site/template improvements |
+| FreeForCharity/FFC-IN-Footer_Only_Template | Footer/legal/cookie/analytics/team layer | Backport compliance/footer/policy improvements |
+| FreeForCharity/FFC-Cloudflare-Automation | Operations and domain automation reference | Backport workflow/environment/issue-form improvements |
+| clarkemoyer/technologyadoptionbarriers.org | Advanced automation/API/reference site | Extract generalized patterns into FFC templates where useful |
+
+## Initial Candidate Improvements
+
+### Read-only vs write-gated environments
+
+- Candidate source: cbmagent-brain environment rollout docs
+- Likely upstream: FreeForCharity/FFC-Cloudflare-Automation
+- Value: Lets agents run DNS/M365/Google audits autonomously while keeping production writes protected.
+- Proposed action: open upstream issue after first implementation in cbmagent-brain is stable.
+
+### Provider usage/agent health reporting
+
+- Candidate source: cbmagent-brain provider usage script
+- Likely upstream: FreeForCharity/FFC-Cloudflare-Automation and/or TABS docs
+- Value: Helps nonprofit automation avoid silent stalls and identify provider/cooldown issues.
+- Proposed action: document as optional agent-ops pattern first.
+
+### GitHub Pages/domain portfolio issue forms
+
+- Candidate source: cbmagent-brain issue forms
+- Likely upstream: FreeForCharity/FFC-Cloudflare-Automation
+- Value: Standardizes domain intake, redirect-only aliases, and GitHub Pages readiness checks.
+- Proposed action: compare with existing FFC issue forms and propose a compatible update.
+
+### TABS advanced workflow extraction
+
+- Candidate source: technologyadoptionbarriers.org workflows
+- Likely upstream: FFC Single Page and Footer Only templates when generally useful
+- Value: API smoke tests, post-deploy smoke checks, SEO reporting, Copilot review cycles, and daily pipelines may help nonprofit sites.
+- Proposed action: triage each TABS workflow as reusable, TABS-specific, or documentation-only.
+
+## Status Legend
+
+- `candidate`: reusable idea identified
+- `triaged`: target upstream repo selected
+- `issue-opened`: upstream issue exists
+- `pr-opened`: upstream PR exists
+- `merged`: upstream contribution merged
+- `not-reusable`: reviewed and intentionally not upstreamed

--- a/references/tabs-alignment.md
+++ b/references/tabs-alignment.md
@@ -1,0 +1,34 @@
+# TABS to Free For Charity Alignment
+
+`clarkemoyer/technologyadoptionbarriers.org` is the advanced automation reference. Not every TABS workflow belongs in nonprofit templates, but reusable patterns should be extracted.
+
+## TABS Patterns to Review
+
+- API smoke tests
+- post-deploy smoke tests
+- Google Analytics reporting
+- Google Search Console reporting
+- Microsoft Clarity integration
+- SEO dashboard sync
+- Lighthouse workflow
+- Copilot review cycle
+- stalled-agent retrigger workflow
+- data/schema validation
+- release notes generation
+- documentation index/onboarding structure
+
+## Extraction Criteria
+
+A TABS pattern is a good Free For Charity upstream candidate if it:
+
+1. helps many nonprofit sites,
+2. does not require TABS-specific APIs or research workflows,
+3. can run with safe defaults,
+4. supports GitHub Pages/static export,
+5. improves accessibility, SEO, quality, security, or maintainability.
+
+## Default Target Repos
+
+- Full site/page/content patterns → `FFC-IN-FFC_Single_Page_Template`
+- Footer/policy/cookie/analytics/team patterns → `FFC-IN-Footer_Only_Template`
+- DNS/domain/workflow/environment/issue-form patterns → `FFC-Cloudflare-Automation`

--- a/standards/source-lineage.md
+++ b/standards/source-lineage.md
@@ -1,0 +1,33 @@
+# Source Lineage Standard
+
+Every derived site or workflow should record its source lineage.
+
+## Required Fields
+
+Use these fields in portfolio registries or repo READMEs when applicable:
+
+```yaml
+source_lineage:
+  primary_template: FreeForCharity/FFC-IN-FFC_Single_Page_Template
+  secondary_template: FreeForCharity/FFC-IN-Footer_Only_Template
+  operations_reference: FreeForCharity/FFC-Cloudflare-Automation
+  advanced_reference: clarkemoyer/technologyadoptionbarriers.org
+  attribution_required: true
+  upstream_giveback_tracking: true
+```
+
+## README Acknowledgement
+
+Derived repos should include an acknowledgement section unless there is a project-specific reason not to.
+
+## Upstream Candidate Trigger
+
+Create an upstream-candidate issue when a downstream change is:
+
+- reusable by other nonprofits,
+- a template bug fix,
+- an accessibility improvement,
+- a GitHub Pages/static export improvement,
+- a workflow/issue-form improvement,
+- a provider/agent operations improvement,
+- a documentation/runbook improvement that reduces nonprofit setup burden.


### PR DESCRIPTION
## Summary\n\n- Adds template alignment tracker connecting portfolio work to Free For Charity source repos\n- Adds source lineage standard for derived sites/workflows\n- Adds TABS-to-Free-For-Charity alignment criteria\n- Seeds initial upstream candidates: read-only environments, provider reporting, domain issue forms, and TABS workflow extraction\n\n## Test / Verification Plan\n\n- [x] Documentation reviewed\n- [x] Source repos and giveback paths explicitly credited\n- [x] No secrets or credentials included\n\nCloses #6