### PR TITLE
fix: move Pages environment to deploy job

### DIFF
--- a/.github/workflows/pages-dashboard.yml
+++ b/.github/workflows/pages-dashboard.yml
@@ -12,10 +12,6 @@ permissions:
   pages: write
   id-token: write
 
-environment:
-  name: github-pages
-  url: ${{ steps.deployment.outputs.page_url }}
-
 concurrency:
   group: pages
   cancel-in-progress: false
@@ -46,6 +42,9 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
## Summary
- Fixes the Pages dashboard workflow syntax by moving the environment block from workflow scope to the deploy job.
- Needed because GitHub rejected workflow_dispatch parsing after the repo was made public and Pages was enabled.

## Test Plan
- [x] YAML parses locally

Refs #51