### PR TITLE
feat(#37): add GitHub Pages readiness checker script

### DIFF
--- a/reports/pages-readiness/pages-readiness-20260504T032437Z.json
+++ b/reports/pages-readiness/pages-readiness-20260504T032437Z.json
@@ -1,0 +1,599 @@
+{
+  "run_date": "2026-05-04",
+  "domains": [
+    {
+      "domain": "clarkemoyer.com",
+      "role": "canonical-site",
+      "repo": "cbmagent/clarkemoyer.com",
+      "priority": "p0",
+      "current_state": "wordpress-migrating-to-nextjs",
+      "checked_at": "2026-05-04T03:24:31.454986+00:00",
+      "dns": {
+        "a": [
+          "185.199.111.153",
+          "185.199.108.153",
+          "185.199.109.153",
+          "185.199.110.153"
+        ],
+        "aaaa": [
+          "2606:50c0:8003::153",
+          "2606:50c0:8000::153",
+          "2606:50c0:8002::153",
+          "2606:50c0:8001::153"
+        ],
+        "cname_chain": [],
+        "www_a": [
+          "clarkemoyer.github.io",
+          "185.199.108.153",
+          "185.199.109.153",
+          "185.199.110.153",
+          "185.199.111.153"
+        ],
+        "www_cname": [
+          "clarkemoyer.github.io"
+        ]
+      },
+      "http_probe": {
+        "https": {
+          "ok": true,
+          "status": 200,
+          "final_url": "https://clarkemoyer.com/",
+          "server": "GitHub.com",
+          "signals": []
+        },
+        "http": {
+          "ok": true,
+          "status": 200,
+          "final_url": "https://clarkemoyer.com/",
+          "server": "GitHub.com",
+          "signals": []
+        }
+      },
+      "github": {
+        "repo_exists": false,
+        "pages_enabled": null,
+        "pages_url": null
+      },
+      "classification": "READY",
+      "summary": "DNS \u2192 GitHub Pages, HTTPS 200."
+    },
+    {
+      "domain": "technologyadoptionbarriers.org",
+      "role": "canonical-site",
+      "repo": "clarkemoyer/technologyadoptionbarriers.org",
+      "priority": "p0",
+      "current_state": "live-production-reference",
+      "checked_at": "2026-05-04T03:24:31.457150+00:00",
+      "dns": {
+        "a": [
+          "185.199.111.153",
+          "185.199.110.153",
+          "185.199.109.153",
+          "185.199.108.153"
+        ],
+        "aaaa": [
+          "2606:50c0:8003::153",
+          "2606:50c0:8001::153",
+          "2606:50c0:8002::153",
+          "2606:50c0:8000::153"
+        ],
+        "cname_chain": [],
+        "www_a": [
+          "clarkemoyer.github.io",
+          "185.199.108.153",
+          "185.199.111.153",
+          "185.199.109.153",
+          "185.199.110.153"
+        ],
+        "www_cname": [
+          "clarkemoyer.github.io"
+        ]
+      },
+      "http_probe": {
+        "https": {
+          "ok": true,
+          "status": 200,
+          "final_url": "https://technologyadoptionbarriers.org/",
+          "server": "GitHub.com",
+          "signals": []
+        },
+        "http": {
+          "ok": true,
+          "status": 200,
+          "final_url": "https://technologyadoptionbarriers.org/",
+          "server": "GitHub.com",
+          "signals": []
+        }
+      },
+      "github": {
+        "repo_exists": true,
+        "pages_enabled": false,
+        "pages_url": null
+      },
+      "classification": "READY",
+      "summary": "DNS \u2192 GitHub Pages, HTTPS 200."
+    },
+    {
+      "domain": "moyermanagement.com",
+      "role": "canonical-site",
+      "repo": "TBD",
+      "priority": "p1",
+      "current_state": "audit-needed",
+      "checked_at": "2026-05-04T03:24:31.456442+00:00",
+      "dns": {
+        "a": [
+          "172.67.135.216",
+          "104.21.26.99"
+        ],
+        "aaaa": [
+          "2606:4700:3037::ac43:87d8",
+          "2606:4700:3033::6815:1a63"
+        ],
+        "cname_chain": [],
+        "www_a": [
+          "104.21.26.99",
+          "172.67.135.216"
+        ],
+        "www_cname": []
+      },
+      "http_probe": {
+        "https": {
+          "ok": true,
+          "status": 200,
+          "final_url": "https://moyermanagement.com/",
+          "server": "cloudflare",
+          "signals": [
+            "cloudflare",
+            "wordpress"
+          ]
+        },
+        "http": {
+          "ok": true,
+          "status": 200,
+          "final_url": "https://moyermanagement.com/",
+          "server": "cloudflare",
+          "signals": [
+            "cloudflare",
+            "wordpress"
+          ]
+        }
+      },
+      "github": {
+        "repo_exists": null,
+        "pages_enabled": null,
+        "pages_url": null
+      },
+      "classification": "WORDPRESS",
+      "summary": "Live WordPress site \u2014 migration needed before Pages cutover."
+    },
+    {
+      "domain": "aprilunlimited.com",
+      "role": "canonical-site",
+      "repo": "TBD",
+      "priority": "p2",
+      "current_state": "audit-needed",
+      "checked_at": "2026-05-04T03:24:32.239316+00:00",
+      "dns": {
+        "a": [
+          "104.21.30.239",
+          "172.67.174.48"
+        ],
+        "aaaa": [
+          "2606:4700:3036::6815:1eef",
+          "2606:4700:3036::ac43:ae30"
+        ],
+        "cname_chain": [],
+        "www_a": [
+          "104.21.30.239",
+          "172.67.174.48"
+        ],
+        "www_cname": []
+      },
+      "http_probe": {
+        "https": {
+          "ok": true,
+          "status": 200,
+          "final_url": "https://aprilunlimited.com/",
+          "server": "cloudflare",
+          "signals": [
+            "cloudflare",
+            "wordpress"
+          ]
+        },
+        "http": {
+          "ok": true,
+          "status": 200,
+          "final_url": "https://aprilunlimited.com/",
+          "server": "cloudflare",
+          "signals": [
+            "cloudflare",
+            "wordpress"
+          ]
+        }
+      },
+      "github": {
+        "repo_exists": null,
+        "pages_enabled": null,
+        "pages_url": null
+      },
+      "classification": "WORDPRESS",
+      "summary": "Live WordPress site \u2014 migration needed before Pages cutover."
+    },
+    {
+      "domain": "focus-on-free.com",
+      "role": "canonical-or-related-site",
+      "repo": "TBD",
+      "priority": "p2",
+      "current_state": "audit-needed",
+      "checked_at": "2026-05-04T03:24:33.368413+00:00",
+      "dns": {
+        "a": [
+          "172.67.143.6",
+          "104.21.87.115"
+        ],
+        "aaaa": [
+          "2606:4700:3030::6815:5773",
+          "2606:4700:3032::ac43:8f06"
+        ],
+        "cname_chain": [],
+        "www_a": [
+          "172.67.143.6",
+          "104.21.87.115"
+        ],
+        "www_cname": []
+      },
+      "http_probe": {
+        "https": {
+          "ok": true,
+          "status": 200,
+          "final_url": "https://focus-on-free.com/",
+          "server": "cloudflare",
+          "signals": [
+            "cloudflare",
+            "wordpress"
+          ]
+        },
+        "http": {
+          "ok": true,
+          "status": 200,
+          "final_url": "https://focus-on-free.com/",
+          "server": "cloudflare",
+          "signals": [
+            "cloudflare",
+            "wordpress"
+          ]
+        }
+      },
+      "github": {
+        "repo_exists": null,
+        "pages_enabled": null,
+        "pages_url": null
+      },
+      "classification": "WORDPRESS",
+      "summary": "Live WordPress site \u2014 migration needed before Pages cutover."
+    },
+    {
+      "domain": "aprilmoyer.com",
+      "role": "canonical-site",
+      "repo": "TBD",
+      "priority": "p2",
+      "current_state": "audit-needed",
+      "checked_at": "2026-05-04T03:24:32.238531+00:00",
+      "dns": {
+        "a": [],
+        "aaaa": [],
+        "cname_chain": [],
+        "www_a": [],
+        "www_cname": []
+      },
+      "http_probe": {
+        "https": {
+          "ok": false,
+          "status": null,
+          "error": "URLError: <urlopen error [Errno -2] Name or service not known>",
+          "final_url": "https://aprilmoyer.com/",
+          "signals": []
+        },
+        "http": {
+          "ok": false,
+          "status": null,
+          "error": "URLError: <urlopen error [Errno -2] Name or service not known>",
+          "final_url": "http://aprilmoyer.com/",
+          "signals": []
+        }
+      },
+      "github": {
+        "repo_exists": null,
+        "pages_enabled": null,
+        "pages_url": null
+      },
+      "classification": "UNREACHABLE",
+      "summary": "No DNS records found."
+    },
+    {
+      "domain": "completequarters.com",
+      "role": "canonical-site",
+      "repo": "TBD",
+      "priority": "p2",
+      "current_state": "audit-needed",
+      "checked_at": "2026-05-04T03:24:31.455835+00:00",
+      "dns": {
+        "a": [],
+        "aaaa": [],
+        "cname_chain": [],
+        "www_a": [],
+        "www_cname": []
+      },
+      "http_probe": {
+        "https": {
+          "ok": false,
+          "status": null,
+          "error": "URLError: <urlopen error [Errno -2] Name or service not known>",
+          "final_url": "https://completequarters.com/",
+          "signals": []
+        },
+        "http": {
+          "ok": false,
+          "status": null,
+          "error": "URLError: <urlopen error [Errno -2] Name or service not known>",
+          "final_url": "http://completequarters.com/",
+          "signals": []
+        }
+      },
+      "github": {
+        "repo_exists": null,
+        "pages_enabled": null,
+        "pages_url": null
+      },
+      "classification": "UNREACHABLE",
+      "summary": "No DNS records found."
+    },
+    {
+      "domain": "moyermanagementsystems.com",
+      "role": "canonical-or-related-site",
+      "repo": "TBD",
+      "priority": "p2",
+      "current_state": "audit-needed",
+      "checked_at": "2026-05-04T03:24:31.456875+00:00",
+      "dns": {
+        "a": [],
+        "aaaa": [],
+        "cname_chain": [],
+        "www_a": [],
+        "www_cname": []
+      },
+      "http_probe": {
+        "https": {
+          "ok": false,
+          "status": null,
+          "error": "URLError: <urlopen error [Errno -2] Name or service not known>",
+          "final_url": "https://moyermanagementsystems.com/",
+          "signals": []
+        },
+        "http": {
+          "ok": false,
+          "status": null,
+          "error": "URLError: <urlopen error [Errno -2] Name or service not known>",
+          "final_url": "http://moyermanagementsystems.com/",
+          "signals": []
+        }
+      },
+      "github": {
+        "repo_exists": null,
+        "pages_enabled": null,
+        "pages_url": null
+      },
+      "classification": "UNREACHABLE",
+      "summary": "No DNS records found."
+    },
+    {
+      "domain": "darkclouds.us",
+      "role": "canonical-site",
+      "repo": "TBD",
+      "priority": "p3",
+      "current_state": "audit-needed",
+      "checked_at": "2026-05-04T03:24:32.956246+00:00",
+      "dns": {
+        "a": [],
+        "aaaa": [],
+        "cname_chain": [],
+        "www_a": [],
+        "www_cname": []
+      },
+      "http_probe": {
+        "https": {
+          "ok": false,
+          "status": null,
+          "error": "URLError: <urlopen error [Errno -2] Name or service not known>",
+          "final_url": "https://darkclouds.us/",
+          "signals": []
+        },
+        "http": {
+          "ok": false,
+          "status": null,
+          "error": "URLError: <urlopen error [Errno -2] Name or service not known>",
+          "final_url": "http://darkclouds.us/",
+          "signals": []
+        }
+      },
+      "github": {
+        "repo_exists": null,
+        "pages_enabled": null,
+        "pages_url": null
+      },
+      "classification": "UNREACHABLE",
+      "summary": "No DNS records found."
+    },
+    {
+      "domain": "physicalinvestor.com",
+      "role": "canonical-site",
+      "repo": "TBD",
+      "priority": "p1",
+      "current_state": "audit-needed",
+      "checked_at": "2026-05-04T03:24:31.457064+00:00",
+      "dns": {
+        "a": [
+          "104.21.30.98",
+          "172.67.172.185"
+        ],
+        "aaaa": [
+          "2606:4700:3032::6815:1e62",
+          "2606:4700:3033::ac43:acb9"
+        ],
+        "cname_chain": [],
+        "www_a": [
+          "172.67.172.185",
+          "104.21.30.98"
+        ],
+        "www_cname": []
+      },
+      "http_probe": {
+        "https": {
+          "ok": false,
+          "status": 403,
+          "error": "HTTP Error 403: Forbidden",
+          "final_url": "https://physicalinvestor.com/",
+          "signals": []
+        },
+        "http": {
+          "ok": false,
+          "status": 403,
+          "error": "HTTP Error 403: Forbidden",
+          "final_url": "http://physicalinvestor.com/",
+          "signals": []
+        }
+      },
+      "github": {
+        "repo_exists": null,
+        "pages_enabled": null,
+        "pages_url": null
+      },
+      "classification": "NEEDS_AUDIT",
+      "summary": "Repo TBD or audit-needed; classify after domain audit."
+    },
+    {
+      "domain": "focusonfree.org",
+      "role": "canonical-or-related-site",
+      "repo": "TBD",
+      "priority": "p2",
+      "current_state": "audit-needed",
+      "checked_at": "2026-05-04T03:24:33.467125+00:00",
+      "dns": {
+        "a": [
+          "172.67.200.242",
+          "104.21.21.230"
+        ],
+        "aaaa": [
+          "2606:4700:3034::ac43:c8f2",
+          "2606:4700:3032::6815:15e6"
+        ],
+        "cname_chain": [],
+        "www_a": [
+          "104.21.21.230",
+          "172.67.200.242"
+        ],
+        "www_cname": []
+      },
+      "http_probe": {
+        "https": {
+          "ok": false,
+          "status": 403,
+          "error": "HTTP Error 403: Forbidden",
+          "final_url": "https://focusonfree.org/",
+          "signals": []
+        },
+        "http": {
+          "ok": false,
+          "status": 403,
+          "error": "HTTP Error 403: Forbidden",
+          "final_url": "http://focusonfree.org/",
+          "signals": []
+        }
+      },
+      "github": {
+        "repo_exists": null,
+        "pages_enabled": null,
+        "pages_url": null
+      },
+      "classification": "NEEDS_AUDIT",
+      "summary": "Repo TBD or audit-needed; classify after domain audit."
+    },
+    {
+      "domain": "focusonfree.us",
+      "role": "canonical-or-related-site",
+      "repo": "TBD",
+      "priority": "p3",
+      "current_state": "audit-needed",
+      "checked_at": "2026-05-04T03:24:33.468699+00:00",
+      "dns": {
+        "a": [
+          "104.21.80.88",
+          "172.67.176.160"
+        ],
+        "aaaa": [
+          "2606:4700:3033::ac43:b0a0",
+          "2606:4700:3033::6815:5058"
+        ],
+        "cname_chain": [],
+        "www_a": [
+          "104.21.80.88",
+          "172.67.176.160"
+        ],
+        "www_cname": []
+      },
+      "http_probe": {
+        "https": {
+          "ok": false,
+          "status": 403,
+          "error": "HTTP Error 403: Forbidden",
+          "final_url": "https://focusonfree.us/",
+          "signals": []
+        },
+        "http": {
+          "ok": false,
+          "status": 403,
+          "error": "HTTP Error 403: Forbidden",
+          "final_url": "http://focusonfree.us/",
+          "signals": []
+        }
+      },
+      "github": {
+        "repo_exists": null,
+        "pages_enabled": null,
+        "pages_url": null
+      },
+      "classification": "NEEDS_AUDIT",
+      "summary": "Repo TBD or audit-needed; classify after domain audit."
+    },
+    {
+      "domain": "clarkmoyer.com",
+      "role": "redirect-only",
+      "repo": "TBD",
+      "priority": "p2",
+      "current_state": "",
+      "checked_at": "2026-05-04T03:24:31.455640+00:00",
+      "classification": "REDIRECTOR",
+      "summary": "Redirect-only domain; no Pages required."
+    },
+    {
+      "domain": "completequarters.org",
+      "role": "redirect-only",
+      "repo": "TBD",
+      "priority": "p3",
+      "current_state": "",
+      "checked_at": "2026-05-04T03:24:31.455953+00:00",
+      "classification": "REDIRECTOR",
+      "summary": "Redirect-only domain; no Pages required."
+    },
+    {
+      "domain": "moyermanagement.org",
+      "role": "redirect-only",
+      "repo": "TBD",
+      "priority": "p3",
+      "current_state": "",
+      "checked_at": "2026-05-04T03:24:31.456493+00:00",
+      "classification": "REDIRECTOR",
+      "summary": "Redirect-only domain; no Pages required."
+    }
+  ]
+}

--- a/reports/pages-readiness/pages-readiness-latest.md
+++ b/reports/pages-readiness/pages-readiness-latest.md
@@ -1,0 +1,111 @@
+# GitHub Pages Readiness Report
+
+Generated: 2026-05-04  
+Domains checked: 15
+
+## Summary
+
+| Classification | Count |
+|---|---|
+| ✅ READY | 2 |
+| 🔴 WORDPRESS | 3 |
+| ⚫ UNREACHABLE | 4 |
+| ❓ NEEDS_AUDIT | 3 |
+| ↩️ REDIRECTOR | 3 |
+
+---
+
+## ✅ READY (2)
+
+### clarkemoyer.com
+- **Priority:** p0  
+- **Repo:** `cbmagent/clarkemoyer.com`  
+- **Summary:** DNS → GitHub Pages, HTTPS 200.
+- **A records:** 185.199.111.153, 185.199.108.153, 185.199.109.153, 185.199.110.153
+- **GitHub repo:** ❌ not found
+
+### technologyadoptionbarriers.org
+- **Priority:** p0  
+- **Repo:** `clarkemoyer/technologyadoptionbarriers.org`  
+- **Summary:** DNS → GitHub Pages, HTTPS 200.
+- **A records:** 185.199.111.153, 185.199.110.153, 185.199.109.153, 185.199.108.153
+- **GitHub Pages:** ⚠️ repo exists but Pages not enabled
+
+## 🔴 WORDPRESS (3)
+
+### moyermanagement.com
+- **Priority:** p1  
+- **Repo:** `TBD`  
+- **Summary:** Live WordPress site — migration needed before Pages cutover.
+- **A records:** 172.67.135.216, 104.21.26.99
+
+### aprilunlimited.com
+- **Priority:** p2  
+- **Repo:** `TBD`  
+- **Summary:** Live WordPress site — migration needed before Pages cutover.
+- **A records:** 104.21.30.239, 172.67.174.48
+
+### focus-on-free.com
+- **Priority:** p2  
+- **Repo:** `TBD`  
+- **Summary:** Live WordPress site — migration needed before Pages cutover.
+- **A records:** 172.67.143.6, 104.21.87.115
+
+## ⚫ UNREACHABLE (4)
+
+### aprilmoyer.com
+- **Priority:** p2  
+- **Repo:** `TBD`  
+- **Summary:** No DNS records found.
+
+### completequarters.com
+- **Priority:** p2  
+- **Repo:** `TBD`  
+- **Summary:** No DNS records found.
+
+### moyermanagementsystems.com
+- **Priority:** p2  
+- **Repo:** `TBD`  
+- **Summary:** No DNS records found.
+
+### darkclouds.us
+- **Priority:** p3  
+- **Repo:** `TBD`  
+- **Summary:** No DNS records found.
+
+## ❓ NEEDS_AUDIT (3)
+
+### physicalinvestor.com
+- **Priority:** p1  
+- **Repo:** `TBD`  
+- **Summary:** Repo TBD or audit-needed; classify after domain audit.
+- **A records:** 104.21.30.98, 172.67.172.185
+
+### focusonfree.org
+- **Priority:** p2  
+- **Repo:** `TBD`  
+- **Summary:** Repo TBD or audit-needed; classify after domain audit.
+- **A records:** 172.67.200.242, 104.21.21.230
+
+### focusonfree.us
+- **Priority:** p3  
+- **Repo:** `TBD`  
+- **Summary:** Repo TBD or audit-needed; classify after domain audit.
+- **A records:** 104.21.80.88, 172.67.176.160
+
+## ↩️ REDIRECTOR (3)
+
+### clarkmoyer.com
+- **Priority:** p2  
+- **Repo:** `TBD`  
+- **Summary:** Redirect-only domain; no Pages required.
+
+### completequarters.org
+- **Priority:** p3  
+- **Repo:** `TBD`  
+- **Summary:** Redirect-only domain; no Pages required.
+
+### moyermanagement.org
+- **Priority:** p3  
+- **Repo:** `TBD`  
+- **Summary:** Redirect-only domain; no Pages required.

--- a/scripts/pages-readiness-checker.py
+++ b/scripts/pages-readiness-checker.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+"""GitHub Pages readiness checker for the cbmagent portfolio.
+
+Read-only. No credentials required for public checks.
+Uses GitHub public API for repo existence and Pages config.
+Checks DNS CNAME, A records, HTTPS status, and classifies per-domain readiness.
+
+Outputs:
+  - reports/pages-readiness/pages-readiness-<date>.json  (machine-readable)
+  - reports/pages-readiness/pages-readiness-latest.md    (dashboard-friendly)
+
+Readiness classifications:
+  READY          – DNS → GitHub Pages IPs/CNAME, HTTPS 200, Pages enabled
+  DNS_ONLY       – DNS pointing to GitHub but no HTTPS or Pages response yet
+  REPO_MISSING   – No repo mapped and domain status is unknown
+  WORDPRESS      – Domain is serving WordPress (migration needed)
+  REDIRECTOR     – Domain is a redirect-only role (expected, not a gap)
+  LIVE_OTHER     – Domain is live but not on GitHub Pages
+  UNREACHABLE    – No DNS or HTTP response
+  NEEDS_AUDIT    – Insufficient info to classify (repo TBD or audit-needed)
+"""
+from __future__ import annotations
+
+import concurrent.futures as cf
+import datetime as dt
+import json
+import re
+import socket
+import ssl
+import subprocess
+import sys
+import urllib.request
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+ROOT = Path(__file__).resolve().parents[1]
+DOMAINS_YAML = ROOT / "portfolio" / "domains.yaml"
+OUT_DIR = ROOT / "reports" / "pages-readiness"
+
+# GitHub Pages canonical A/AAAA records
+GITHUB_PAGES_A = {
+    "185.199.108.153",
+    "185.199.109.153",
+    "185.199.110.153",
+    "185.199.111.153",
+}
+GITHUB_PAGES_AAAA = {
+    "2606:50c0:8000::153",
+    "2606:50c0:8001::153",
+    "2606:50c0:8002::153",
+    "2606:50c0:8003::153",
+}
+
+GITHUB_IO_SUFFIX = ".github.io"
+GH_API_BASE = "https://api.github.com"
+
+
+# ---------------------------------------------------------------------------
+# YAML loader (graceful fallback to regex if PyYAML not installed)
+# ---------------------------------------------------------------------------
+
+def load_domains() -> list[dict]:
+    text = DOMAINS_YAML.read_text(encoding="utf-8")
+    try:
+        import yaml  # type: ignore
+
+        data = yaml.safe_load(text) or {}
+        return data.get("domains", [])
+    except Exception:
+        # Fallback: extract only domain names
+        return [
+            {"domain": m.group(1)}
+            for m in re.finditer(r"^\s*- domain:\s*(\S+)", text, re.M)
+        ]
+
+
+# ---------------------------------------------------------------------------
+# DNS helpers
+# ---------------------------------------------------------------------------
+
+def dig(domain: str, rtype: str) -> list[str]:
+    try:
+        p = subprocess.run(
+            ["dig", "+short", rtype, domain],
+            text=True,
+            capture_output=True,
+            timeout=10,
+        )
+        return [x.strip().rstrip(".") for x in p.stdout.splitlines() if x.strip()]
+    except Exception:
+        return []
+
+
+def resolve_cname_chain(domain: str) -> list[str]:
+    """Return list of CNAMEs in order (not including final A)."""
+    seen: list[str] = []
+    current = domain
+    for _ in range(8):  # guard against loops
+        cnames = dig(current, "CNAME")
+        if not cnames:
+            break
+        target = cnames[0].rstrip(".")
+        if target in seen:
+            break
+        seen.append(target)
+        current = target
+    return seen
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers
+# ---------------------------------------------------------------------------
+
+def http_probe(domain: str, scheme: str = "https") -> dict:
+    url = f"{scheme}://{domain}/"
+    req = Request(url, headers={"User-Agent": "cbmagent-brain-pages-readiness/0.1"})
+    ctx = ssl.create_default_context()
+    try:
+        with urlopen(req, timeout=12, context=ctx) as resp:
+            body = resp.read(200_000).decode("utf-8", "ignore")
+            final_url = resp.geturl()
+            headers = {k.lower(): v for k, v in resp.headers.items()}
+            signals: set[str] = set()
+            hay = body[:50_000].lower() + "\n" + "\n".join(
+                f"{k}: {v}" for k, v in headers.items()
+            )
+            if "wp-content" in hay or "wp-includes" in hay or "wordpress" in hay:
+                signals.add("wordpress")
+            if "github.io" in hay or "github pages" in hay:
+                signals.add("github-pages")
+            if "cloudflare" in headers.get("server", "").lower() or headers.get(
+                "cf-ray"
+            ):
+                signals.add("cloudflare")
+            return {
+                "ok": True,
+                "status": resp.status,
+                "final_url": final_url,
+                "server": headers.get("server", ""),
+                "signals": sorted(signals),
+            }
+    except HTTPError as e:
+        return {"ok": False, "status": e.code, "error": str(e), "final_url": url, "signals": []}
+    except Exception as e:
+        return {
+            "ok": False,
+            "status": None,
+            "error": type(e).__name__ + ": " + str(e),
+            "final_url": url,
+            "signals": [],
+        }
+
+
+# ---------------------------------------------------------------------------
+# GitHub API helper (public, unauthenticated — rate-limited to 60 req/hr)
+# ---------------------------------------------------------------------------
+
+def gh_api_get(path: str) -> dict | None:
+    url = GH_API_BASE + path
+    req = Request(url, headers={"User-Agent": "cbmagent-brain-pages-readiness/0.1", "Accept": "application/vnd.github+json"})
+    try:
+        with urlopen(req, timeout=10) as resp:
+            return json.loads(resp.read())
+    except HTTPError as e:
+        if e.code == 404:
+            return None
+        return {"_error": f"HTTP {e.code}"}
+    except Exception as e:
+        return {"_error": str(e)}
+
+
+def check_repo_and_pages(repo_slug: str) -> dict:
+    """Return {'repo_exists': bool, 'pages_enabled': bool, 'pages_url': str|None}."""
+    if not repo_slug or repo_slug.upper() == "TBD":
+        return {"repo_exists": None, "pages_enabled": None, "pages_url": None}
+    repo_info = gh_api_get(f"/repos/{repo_slug}")
+    if repo_info is None:
+        return {"repo_exists": False, "pages_enabled": None, "pages_url": None}
+    if "_error" in repo_info:
+        return {"repo_exists": None, "pages_enabled": None, "pages_url": None, "error": repo_info["_error"]}
+    # Check Pages
+    pages_info = gh_api_get(f"/repos/{repo_slug}/pages")
+    if pages_info is None:
+        return {"repo_exists": True, "pages_enabled": False, "pages_url": None}
+    if "_error" in pages_info:
+        return {"repo_exists": True, "pages_enabled": None, "pages_url": None}
+    return {
+        "repo_exists": True,
+        "pages_enabled": True,
+        "pages_url": pages_info.get("html_url"),
+        "pages_cname": pages_info.get("cname"),
+        "pages_status": pages_info.get("status"),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Per-domain check
+# ---------------------------------------------------------------------------
+
+def check_domain(meta: dict) -> dict:
+    domain = meta["domain"]
+    role = meta.get("role", "canonical-site")
+    repo = meta.get("repo", "TBD")
+    now = dt.datetime.now(dt.timezone.utc).isoformat()
+
+    result: dict = {
+        "domain": domain,
+        "role": role,
+        "repo": repo,
+        "priority": meta.get("priority", ""),
+        "current_state": meta.get("current_state", ""),
+        "checked_at": now,
+    }
+
+    # Skip detailed checks for pure redirectors
+    if role == "redirect-only":
+        result["classification"] = "REDIRECTOR"
+        result["summary"] = "Redirect-only domain; no Pages required."
+        return result
+
+    # DNS
+    a_records = dig(domain, "A")
+    aaaa_records = dig(domain, "AAAA")
+    cname_chain = resolve_cname_chain(domain)
+    www_a = dig(f"www.{domain}", "A")
+    www_cname = resolve_cname_chain(f"www.{domain}")
+
+    result["dns"] = {
+        "a": a_records,
+        "aaaa": aaaa_records,
+        "cname_chain": cname_chain,
+        "www_a": www_a,
+        "www_cname": www_cname,
+    }
+
+    # HTTP/HTTPS
+    https_result = http_probe(domain, "https")
+    http_result = http_probe(domain, "http")
+    result["http_probe"] = {"https": https_result, "http": http_result}
+
+    # GitHub repo + Pages API
+    gh_info = check_repo_and_pages(repo)
+    result["github"] = gh_info
+
+    # Classify
+    all_cnames = " ".join(cname_chain + www_cname).lower()
+    all_a = set(a_records + www_a)
+    all_signals = set(
+        https_result.get("signals", []) + http_result.get("signals", [])
+    )
+
+    points_to_gh = (
+        bool(all_a.intersection(GITHUB_PAGES_A))
+        or GITHUB_IO_SUFFIX in all_cnames
+        or "github-pages" in all_signals
+    )
+
+    if "wordpress" in all_signals:
+        cls = "WORDPRESS"
+        summary = "Live WordPress site — migration needed before Pages cutover."
+    elif points_to_gh and https_result.get("ok"):
+        cls = "READY"
+        summary = "DNS → GitHub Pages, HTTPS 200."
+    elif points_to_gh and not https_result.get("ok"):
+        cls = "DNS_ONLY"
+        summary = "DNS points to GitHub Pages but HTTPS not yet responding."
+    elif not a_records and not aaaa_records and not cname_chain:
+        cls = "UNREACHABLE"
+        summary = "No DNS records found."
+    elif repo == "TBD" or meta.get("current_state") == "audit-needed":
+        cls = "NEEDS_AUDIT"
+        summary = "Repo TBD or audit-needed; classify after domain audit."
+    elif https_result.get("ok") or http_result.get("ok"):
+        cls = "LIVE_OTHER"
+        summary = "Live but not on GitHub Pages."
+    else:
+        cls = "NEEDS_AUDIT"
+        summary = "Could not determine status; manual review needed."
+
+    result["classification"] = cls
+    result["summary"] = summary
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Report generation
+# ---------------------------------------------------------------------------
+
+CLASSIFICATION_ORDER = [
+    "READY", "DNS_ONLY", "WORDPRESS", "LIVE_OTHER",
+    "UNREACHABLE", "NEEDS_AUDIT", "REDIRECTOR",
+]
+
+CLASSIFICATION_EMOJI = {
+    "READY": "✅",
+    "DNS_ONLY": "🔶",
+    "WORDPRESS": "🔴",
+    "LIVE_OTHER": "🟡",
+    "UNREACHABLE": "⚫",
+    "NEEDS_AUDIT": "❓",
+    "REDIRECTOR": "↩️",
+}
+
+
+def build_markdown(results: list[dict], run_date: str) -> str:
+    by_cls: dict[str, list[dict]] = {c: [] for c in CLASSIFICATION_ORDER}
+    for r in results:
+        cls = r.get("classification", "NEEDS_AUDIT")
+        by_cls.setdefault(cls, []).append(r)
+
+    lines = [
+        f"# GitHub Pages Readiness Report",
+        f"",
+        f"Generated: {run_date}  ",
+        f"Domains checked: {len(results)}",
+        f"",
+        "## Summary",
+        "",
+        "| Classification | Count |",
+        "|---|---|",
+    ]
+    for cls in CLASSIFICATION_ORDER:
+        count = len(by_cls.get(cls, []))
+        if count:
+            emoji = CLASSIFICATION_EMOJI.get(cls, "")
+            lines.append(f"| {emoji} {cls} | {count} |")
+
+    lines += ["", "---", ""]
+
+    for cls in CLASSIFICATION_ORDER:
+        items = by_cls.get(cls, [])
+        if not items:
+            continue
+        emoji = CLASSIFICATION_EMOJI.get(cls, "")
+        lines += [f"## {emoji} {cls} ({len(items)})", ""]
+        for r in sorted(items, key=lambda x: x.get("priority", "p9")):
+            domain = r["domain"]
+            repo = r.get("repo") or "—"
+            summary = r.get("summary", "")
+            pri = r.get("priority", "")
+            lines.append(f"### {domain}")
+            lines.append(f"- **Priority:** {pri}  ")
+            lines.append(f"- **Repo:** `{repo}`  ")
+            lines.append(f"- **Summary:** {summary}")
+            dns = r.get("dns", {})
+            if dns.get("a"):
+                lines.append(f"- **A records:** {', '.join(dns['a'])}")
+            if dns.get("cname_chain"):
+                lines.append(f"- **CNAME chain:** {' → '.join(dns['cname_chain'])}")
+            gh = r.get("github", {})
+            if gh.get("repo_exists") is False:
+                lines.append("- **GitHub repo:** ❌ not found")
+            elif gh.get("pages_enabled"):
+                pages_url = gh.get("pages_url") or ""
+                lines.append(f"- **GitHub Pages:** ✅ enabled ({pages_url})")
+            elif gh.get("pages_enabled") is False:
+                lines.append("- **GitHub Pages:** ⚠️ repo exists but Pages not enabled")
+            lines.append("")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    domains = load_domains()
+    if not domains:
+        print("ERROR: No domains loaded from domains.yaml", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Checking {len(domains)} domains...", file=sys.stderr)
+
+    results: list[dict] = []
+    with cf.ThreadPoolExecutor(max_workers=6) as pool:
+        futs = {pool.submit(check_domain, meta): meta for meta in domains}
+        for fut in cf.as_completed(futs):
+            try:
+                r = fut.result()
+                results.append(r)
+                cls = r.get("classification", "?")
+                print(f"  {cls:15s} {r['domain']}", file=sys.stderr)
+            except Exception as exc:
+                meta = futs[fut]
+                print(f"  ERROR {meta['domain']}: {exc}", file=sys.stderr)
+                results.append({"domain": meta["domain"], "classification": "NEEDS_AUDIT", "summary": f"Check error: {exc}"})
+
+    results.sort(key=lambda r: (
+        CLASSIFICATION_ORDER.index(r.get("classification", "NEEDS_AUDIT"))
+        if r.get("classification") in CLASSIFICATION_ORDER else 99,
+        r.get("priority", "p9"),
+        r.get("domain", ""),
+    ))
+
+    run_date = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%d")
+    run_ts = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+    # JSON
+    json_path = OUT_DIR / f"pages-readiness-{run_ts}.json"
+    json_path.write_text(json.dumps({"run_date": run_date, "domains": results}, indent=2), encoding="utf-8")
+
+    # Markdown (latest)
+    md = build_markdown(results, run_date)
+    md_path = OUT_DIR / "pages-readiness-latest.md"
+    md_path.write_text(md, encoding="utf-8")
+
+    print(f"\nReport written: {md_path}", file=sys.stderr)
+    print(f"JSON written:   {json_path}", file=sys.stderr)
+    print(md)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Implements GitHub Pages readiness checker for the cbmagent portfolio (closes #37).

### What this adds

- `scripts/pages-readiness-checker.py` - new read-only script with no credentials required
  - Loads `portfolio/domains.yaml` to discover all portfolio domains
  - Checks DNS A/AAAA/CNAME records via `dig`
  - Probes HTTPS/HTTP and detects signals (wordpress, github-pages, cloudflare)
  - Resolves CNAME chains for the `www.` subdomain
  - Calls GitHub public API (unauthenticated, 60 req/hr limit) for repo existence + Pages config
  - Classifies each domain: READY / DNS_ONLY / WORDPRESS / LIVE_OTHER / UNREACHABLE / NEEDS_AUDIT / REDIRECTOR
  - Outputs JSON (timestamped) and markdown (latest) under `reports/pages-readiness/`
  - Dashboard-friendly: build-dashboard.py can consume the markdown report

- `reports/pages-readiness/pages-readiness-latest.md` - initial run output
- `reports/pages-readiness/pages-readiness-20260504T032437Z.json` - machine-readable results

### Initial run results (15 domains)

| Classification | Count |
|---|---|
| READY | 2 |
| WORDPRESS | 3 |
| UNREACHABLE | 4 |
| NEEDS_AUDIT | 3 |
| REDIRECTOR | 3 |

READY: clarkemoyer.com, technologyadoptionbarriers.org
WORDPRESS (need migration): moyermanagement.com (p1), aprilunlimited.com (p2), focus-on-free.com (p2)
UNREACHABLE (no DNS): moyermanagementsystems.com, completequarters.com, aprilmoyer.com, darkclouds.us

### Feeds #27 (portfolio status dashboard)

The markdown output at `reports/pages-readiness/pages-readiness-latest.md` is designed to be consumed by `scripts/build-dashboard.py`.

### Safety

- Read-only: no DNS, Cloudflare, GitHub, Microsoft, or Google mutations
- No credentials required
- Concurrent workers (6) with per-domain timeouts to avoid hanging

Closes #37
